### PR TITLE
fix: treat firewall zones/policies as optional endpoints

### DIFF
--- a/crates/unifly-api/src/controller.rs
+++ b/crates/unifly-api/src/controller.rs
@@ -514,18 +514,17 @@ impl Controller {
                     .collect()
             };
             let wifi: Vec<WifiBroadcast> = wifi_res?.into_iter().map(WifiBroadcast::from).collect();
-            let policies: Vec<FirewallPolicy> = policies_res?
-                .into_iter()
-                .map(FirewallPolicy::from)
-                .collect();
-            let zones: Vec<FirewallZone> = zones_res?.into_iter().map(FirewallZone::from).collect();
+
             let sites: Vec<Site> = sites_res?.into_iter().map(Site::from).collect();
             let traffic_matching_lists: Vec<TrafficMatchingList> = tml_res?
                 .into_iter()
                 .map(TrafficMatchingList::from)
                 .collect();
 
-            // Optional endpoints — 404 means the controller doesn't support them
+            // Optional endpoints — errors (404, not-configured, etc.) are non-fatal
+            let policies: Vec<FirewallPolicy> =
+                unwrap_or_empty("firewall/policies", policies_res);
+            let zones: Vec<FirewallZone> = unwrap_or_empty("firewall/zones", zones_res);
             let acls: Vec<AclRule> = unwrap_or_empty("acl/rules", acls_res);
             let dns: Vec<DnsPolicy> = unwrap_or_empty("dns/policies", dns_res);
             let vouchers: Vec<Voucher> = unwrap_or_empty("vouchers", vouchers_res);


### PR DESCRIPTION
## Summary

- Controllers without zone-based firewall configured return `api.firewall.zone-based-firewall-not-configured`, which causes `full_refresh()` to fail fatally — breaking **all** CLI commands including unrelated ones like `clients list`
- Changed `zones_res?` and `policies_res?` to use the existing `unwrap_or_empty()` helper, making firewall data optional just like ACLs, DNS policies, and vouchers
- Moved firewall zones/policies into the "Optional endpoints" section alongside the other non-fatal fetches

## Problem

Any UDM/UDR controller that does not have zone-based firewall configured will return `api.firewall.zone-based-firewall-not-configured` when the firewall zones or policies endpoints are queried. Because `full_refresh()` treats these as fatal (`?` operator), **every** CLI command fails — even completely unrelated ones like `clients list` or `devices list`.

## Fix

The codebase already has the `unwrap_or_empty()` helper (used for ACLs, DNS policies, and vouchers) that gracefully handles 404s and other errors by logging a warning and returning an empty collection. This PR applies the same pattern to firewall zones and policies.

## How to reproduce

Connect unifly to any UniFi Dream Machine or Dream Router that does not have zone-based firewall configured, then run any command (e.g. `unifly clients list`).

---

> This PR was authored on behalf of @schickling