### PR TITLE
Make tachyonfx sendable to fix clippy warning

### DIFF
--- a/crates/unifly/Cargo.toml
+++ b/crates/unifly/Cargo.toml
@@ -94,7 +94,7 @@ opaline            = { workspace = true, optional = true }
 ratatui            = { workspace = true, optional = true }
 ratatui-macros     = { workspace = true, optional = true }
 crossterm          = { workspace = true, optional = true }
-tachyonfx          = { workspace = true, optional = true }
+tachyonfx          = { workspace = true, optional = true, features = ["sendable"] }
 tui-input          = { workspace = true, optional = true }
 tui-scrollview     = { workspace = true, optional = true }
 tui-widget-list    = { workspace = true, optional = true }


### PR DESCRIPTION
## What

Add the `sendable` feature to `tachyonfx` to make `tui::app::App` Send-capable again.

## Why
Clippy step was failing e.g. https://github.com/hyperb1iss/unifly/actions/runs/24253822728/job/70820056388#step:8:43
```rust
error: future cannot be sent between threads safely
   --> crates/unifly/src/tui/app.rs:166:36
    |
166 |     pub async fn run(&mut self) -> Result<()> {
    |                                    ^^^^^^^^^^ future returned by `run` is not `Send`
    |
note: future is not `Send` as this value is used across an await
   --> crates/unifly/src/tui/app.rs:193:45
    |
166 |     pub async fn run(&mut self) -> Result<()> {
    |                      --------- has type `&mut tui::app::App` which is not `Send`
...
193 |             let Some(event) = events.next().await else {
    |                                             ^^^^^ await occurs here, with `&mut self` maybe used later
    = note: `std::rc::Rc<std::cell::RefCell<tachyonfx::fx::unique::UniqueContext>>` doesn't implement `std::marker::Send`
note: future is not `Send` as this value is used across an await
   --> crates/unifly/src/tui/app.rs:193:45
    |
166 |     pub async fn run(&mut self) -> Result<()> {
    |                      --------- has type `&mut tui::app::App` which is not `Send`
...
193 |             let Some(event) = events.next().await else {
    |                                             ^^^^^ await occurs here, with `&mut self` maybe used later
    = note: `(dyn tachyonfx::Shader + 'static)` doesn't implement `std::marker::Send`
```

## How to Test

`cargo clippy`

## Checklist

- [x] `just check` passes (fmt + clippy + test)
- [ ] New commands are documented in `skills/unifly/SKILL.md`
- [x] No credentials or secrets in the diff
