### PR TITLE
fix(cli): firewall policy --from-file fixes + PortSpec schema

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Added
 
+- **`--after-system` on `firewall policies create`** to place a newly
+  created policy after system-defined rules in one step (previously only
+  available on `reorder`).
+- **`--from-file` shorthand fields** for firewall policies: `dst_ip`,
+  `dst_port`, `src_ip`, `src_port`, `dst_network`, `src_network` in
+  policy JSON files are now resolved into the canonical
+  `source_filter`/`destination_filter` before submission. Combined IP +
+  port filters correctly nest `portFilter` inside `ipAddressFilter`.
 - **`config cloud-setup`** guided onboarding for Site Manager profiles with
   API key validation, console selection, site discovery, and profile writing
 - **`cloud` command group** for Site Manager fleet visibility: `hosts`,
@@ -71,6 +79,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
     `docs/guide/**` updated to reflect the new nomenclature.
   - `EntityId::Legacy(String)` is **kept** — that variant names an ID
     format (MongoDB ObjectId string vs UUID), not the API surface.
+
+### Fixed
+
+- Port range items in firewall policy payloads now serialize as
+  `PORT_NUMBER_RANGE` instead of `PORT_RANGE`, which the UDM API rejects.
+  `PORT_RANGE` is still accepted on read for backward compatibility.
 
 ## [0.8.0] - 2026-04-05
 

--- a/crates/unifly-api/src/command/mod.rs
+++ b/crates/unifly-api/src/command/mod.rs
@@ -17,7 +17,7 @@ pub use requests::{
     CreateFirewallZoneRequest, CreateNatPolicyRequest, CreateNetworkRequest,
     CreateRemoteAccessVpnServerRequest, CreateSiteToSiteVpnRequest,
     CreateTrafficMatchingListRequest, CreateVouchersRequest, CreateVpnClientProfileRequest,
-    CreateWifiBroadcastRequest, CreateWireGuardPeerRequest, TrafficFilterSpec,
+    CreateWifiBroadcastRequest, CreateWireGuardPeerRequest, PortSpec, TrafficFilterSpec,
     UpdateAclRuleRequest, UpdateDnsPolicyRequest, UpdateFirewallPolicyRequest,
     UpdateFirewallZoneRequest, UpdateNatPolicyRequest, UpdateNetworkRequest,
     UpdateRemoteAccessVpnServerRequest, UpdateSiteToSiteVpnRequest,
@@ -281,6 +281,7 @@ pub enum Command {
 #[derive(Debug)]
 pub enum CommandResult {
     Ok,
+    CreatedId(EntityId),
     Device(Device),
     Client(Client),
     Network(Network),

--- a/crates/unifly-api/src/command/mod.rs
+++ b/crates/unifly-api/src/command/mod.rs
@@ -134,8 +134,8 @@ pub enum Command {
     },
     ReorderFirewallPolicies {
         zone_pair: (EntityId, EntityId),
-        ordered_ids: Vec<EntityId>,
-        after_system: bool,
+        before_system_ids: Vec<EntityId>,
+        after_system_ids: Vec<EntityId>,
     },
     CreateFirewallZone(CreateFirewallZoneRequest),
     UpdateFirewallZone {

--- a/crates/unifly-api/src/command/requests.rs
+++ b/crates/unifly-api/src/command/requests.rs
@@ -17,8 +17,8 @@ pub use network::{
 };
 pub use policy::{
     CreateAclRuleRequest, CreateFirewallPolicyRequest, CreateFirewallZoneRequest,
-    CreateNatPolicyRequest, TrafficFilterSpec, UpdateAclRuleRequest, UpdateFirewallPolicyRequest,
-    UpdateFirewallZoneRequest, UpdateNatPolicyRequest,
+    CreateNatPolicyRequest, PortSpec, TrafficFilterSpec, UpdateAclRuleRequest,
+    UpdateFirewallPolicyRequest, UpdateFirewallZoneRequest, UpdateNatPolicyRequest,
 };
 pub use traffic::{CreateTrafficMatchingListRequest, UpdateTrafficMatchingListRequest};
 pub use vouchers::CreateVouchersRequest;

--- a/crates/unifly-api/src/command/requests/policy.rs
+++ b/crates/unifly-api/src/command/requests/policy.rs
@@ -27,6 +27,20 @@ pub struct CreateFirewallPolicyRequest {
     pub source_filter: Option<TrafficFilterSpec>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub destination_filter: Option<TrafficFilterSpec>,
+
+    // Shorthand fields for --from-file convenience (map to source/destination_filter)
+    #[serde(default, skip_serializing)]
+    pub src_network: Option<Vec<String>>,
+    #[serde(default, skip_serializing)]
+    pub src_ip: Option<Vec<String>>,
+    #[serde(default, skip_serializing)]
+    pub src_port: Option<Vec<String>>,
+    #[serde(default, skip_serializing)]
+    pub dst_network: Option<Vec<String>>,
+    #[serde(default, skip_serializing)]
+    pub dst_ip: Option<Vec<String>>,
+    #[serde(default, skip_serializing)]
+    pub dst_port: Option<Vec<String>>,
 }
 
 fn default_true() -> bool {
@@ -55,26 +69,280 @@ pub struct UpdateFirewallPolicyRequest {
     pub destination_filter: Option<TrafficFilterSpec>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub logging_enabled: Option<bool>,
+
+    // Shorthand fields for --from-file convenience (map to source/destination_filter)
+    #[serde(default, skip_serializing)]
+    pub src_network: Option<Vec<String>>,
+    #[serde(default, skip_serializing)]
+    pub src_ip: Option<Vec<String>>,
+    #[serde(default, skip_serializing)]
+    pub src_port: Option<Vec<String>>,
+    #[serde(default, skip_serializing)]
+    pub dst_network: Option<Vec<String>>,
+    #[serde(default, skip_serializing)]
+    pub dst_ip: Option<Vec<String>>,
+    #[serde(default, skip_serializing)]
+    pub dst_port: Option<Vec<String>>,
+}
+
+/// Port-side specification: either inline values or a reference to a
+/// firewall port-group by its `external_id`. Mirrors the controller's
+/// portFilter wire shape.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(tag = "type", rename_all = "snake_case")]
+pub enum PortSpec {
+    /// Inline port values (single ports or ranges like `"8000-9000"`).
+    Values {
+        items: Vec<String>,
+        #[serde(default)]
+        match_opposite: bool,
+    },
+    /// Reference to a port-group via its `external_id` UUID.
+    MatchingList {
+        list_id: String,
+        #[serde(default)]
+        match_opposite: bool,
+    },
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
-#[serde(tag = "type", rename_all = "snake_case")]
+#[serde(
+    tag = "type",
+    rename_all = "snake_case",
+    from = "TrafficFilterSpecWire"
+)]
 pub enum TrafficFilterSpec {
     Network {
         network_ids: Vec<String>,
         #[serde(default)]
         match_opposite: bool,
+        /// Optional port restriction (the API nests portFilter inside the
+        /// network/IP filter rather than treating it as a separate type).
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        ports: Option<PortSpec>,
     },
     IpAddress {
         addresses: Vec<String>,
         #[serde(default)]
         match_opposite: bool,
+        /// Optional port restriction.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        ports: Option<PortSpec>,
     },
     Port {
-        ports: Vec<String>,
+        ports: PortSpec,
+    },
+}
+
+/// Internal wire-format wrapper used during deserialization to accept the
+/// pre-PortSpec shape from existing JSON files. The legacy `Port` variant
+/// stored ports as a flat `Vec<String>` with `match_opposite` at the
+/// variant level instead of nested inside `PortSpec`. Both shapes round
+/// through here into [`TrafficFilterSpec`].
+#[derive(Deserialize)]
+#[serde(tag = "type", rename_all = "snake_case")]
+enum TrafficFilterSpecWire {
+    Network {
+        network_ids: Vec<String>,
+        #[serde(default)]
+        match_opposite: bool,
+        #[serde(default, deserialize_with = "deserialize_port_spec_opt")]
+        ports: Option<PortSpec>,
+    },
+    IpAddress {
+        addresses: Vec<String>,
+        #[serde(default)]
+        match_opposite: bool,
+        #[serde(default, deserialize_with = "deserialize_port_spec_opt")]
+        ports: Option<PortSpec>,
+    },
+    Port {
+        #[serde(deserialize_with = "deserialize_port_spec")]
+        ports: PortSpec,
+        /// Legacy field: pre-PortSpec the Port variant carried
+        /// `match_opposite` at the variant level. Folded into the inner
+        /// `PortSpec` during conversion.
         #[serde(default)]
         match_opposite: bool,
     },
+}
+
+impl From<TrafficFilterSpecWire> for TrafficFilterSpec {
+    fn from(wire: TrafficFilterSpecWire) -> Self {
+        match wire {
+            TrafficFilterSpecWire::Network {
+                network_ids,
+                match_opposite,
+                ports,
+            } => Self::Network {
+                network_ids,
+                match_opposite,
+                ports,
+            },
+            TrafficFilterSpecWire::IpAddress {
+                addresses,
+                match_opposite,
+                ports,
+            } => Self::IpAddress {
+                addresses,
+                match_opposite,
+                ports,
+            },
+            TrafficFilterSpecWire::Port {
+                mut ports,
+                match_opposite: legacy_mo,
+            } => {
+                if legacy_mo {
+                    match &mut ports {
+                        PortSpec::Values { match_opposite, .. }
+                        | PortSpec::MatchingList { match_opposite, .. } => {
+                            *match_opposite = *match_opposite || legacy_mo;
+                        }
+                    }
+                }
+                Self::Port { ports }
+            }
+        }
+    }
+}
+
+/// Deserialize a [`PortSpec`] from either the new tagged shape
+/// (`{"type": "values", "items": [...]}`) or the legacy flat
+/// `Vec<String>` array used pre-PortSpec.
+fn deserialize_port_spec<'de, D>(deserializer: D) -> Result<PortSpec, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    #[derive(Deserialize)]
+    #[serde(untagged)]
+    enum Compat {
+        Tagged(PortSpec),
+        LegacyArray(Vec<String>),
+    }
+    Ok(match Compat::deserialize(deserializer)? {
+        Compat::Tagged(spec) => spec,
+        Compat::LegacyArray(items) => PortSpec::Values {
+            items,
+            match_opposite: false,
+        },
+    })
+}
+
+fn deserialize_port_spec_opt<'de, D>(deserializer: D) -> Result<Option<PortSpec>, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    #[derive(Deserialize)]
+    #[serde(untagged)]
+    enum Compat {
+        Tagged(PortSpec),
+        LegacyArray(Vec<String>),
+    }
+    let opt: Option<Compat> = Option::deserialize(deserializer)?;
+    Ok(opt.map(|compat| match compat {
+        Compat::Tagged(spec) => spec,
+        Compat::LegacyArray(items) => PortSpec::Values {
+            items,
+            match_opposite: false,
+        },
+    }))
+}
+
+impl CreateFirewallPolicyRequest {
+    /// Convert shorthand `src_ip`/`dst_ip`/`src_port`/`dst_port`/`src_network`/
+    /// `dst_network` fields into the canonical `source_filter`/`destination_filter`.
+    ///
+    /// Returns `Err` if both a shorthand field and the corresponding filter are set,
+    /// or if more than one shorthand family is specified for the same side.
+    pub fn resolve_filters(&mut self) -> Result<(), String> {
+        self.source_filter = resolve_side(
+            "src",
+            self.source_filter.take(),
+            self.src_network.take(),
+            self.src_ip.take(),
+            self.src_port.take(),
+        )?;
+        self.destination_filter = resolve_side(
+            "dst",
+            self.destination_filter.take(),
+            self.dst_network.take(),
+            self.dst_ip.take(),
+            self.dst_port.take(),
+        )?;
+        Ok(())
+    }
+}
+
+impl UpdateFirewallPolicyRequest {
+    /// Same as [`CreateFirewallPolicyRequest::resolve_filters`].
+    pub fn resolve_filters(&mut self) -> Result<(), String> {
+        self.source_filter = resolve_side(
+            "src",
+            self.source_filter.take(),
+            self.src_network.take(),
+            self.src_ip.take(),
+            self.src_port.take(),
+        )?;
+        self.destination_filter = resolve_side(
+            "dst",
+            self.destination_filter.take(),
+            self.dst_network.take(),
+            self.dst_ip.take(),
+            self.dst_port.take(),
+        )?;
+        Ok(())
+    }
+}
+
+fn resolve_side(
+    prefix: &str,
+    existing: Option<TrafficFilterSpec>,
+    networks: Option<Vec<String>>,
+    ips: Option<Vec<String>>,
+    ports: Option<Vec<String>>,
+) -> Result<Option<TrafficFilterSpec>, String> {
+    // network + ip is invalid; port can combine with either network or ip
+    if networks.is_some() && ips.is_some() {
+        return Err(format!("cannot combine {prefix}_network and {prefix}_ip"));
+    }
+
+    let has_shorthand = networks.is_some() || ips.is_some() || ports.is_some();
+
+    if has_shorthand && existing.is_some() {
+        return Err(format!(
+            "cannot combine shorthand fields with {prefix_filter}",
+            prefix_filter = if prefix == "src" {
+                "source_filter"
+            } else {
+                "destination_filter"
+            }
+        ));
+    }
+
+    if let Some(existing) = existing {
+        return Ok(Some(existing));
+    }
+
+    let port_spec = ports.map(|items| PortSpec::Values {
+        items,
+        match_opposite: false,
+    });
+
+    Ok(if let Some(network_ids) = networks {
+        Some(TrafficFilterSpec::Network {
+            network_ids,
+            match_opposite: false,
+            ports: port_spec,
+        })
+    } else if let Some(addresses) = ips {
+        Some(TrafficFilterSpec::IpAddress {
+            addresses,
+            match_opposite: false,
+            ports: port_spec,
+        })
+    } else {
+        port_spec.map(|ports| TrafficFilterSpec::Port { ports })
+    })
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -225,8 +493,254 @@ pub struct UpdateNatPolicyRequest {
 
 #[cfg(test)]
 mod tests {
-    use super::{CreateAclRuleRequest, UpdateAclRuleRequest};
+    use super::{
+        CreateAclRuleRequest, CreateFirewallPolicyRequest, PortSpec, TrafficFilterSpec,
+        UpdateAclRuleRequest, UpdateFirewallPolicyRequest,
+    };
     use crate::model::FirewallAction;
+
+    /// Bug 1 regression: dst_ip and dst_port in --from-file JSON must
+    /// deserialize into the shorthand fields (not be silently dropped).
+    #[test]
+    fn create_firewall_policy_shorthand_fields_deserialize() {
+        let req: CreateFirewallPolicyRequest = serde_json::from_value(serde_json::json!({
+            "name": "Allow Awair",
+            "action": "Allow",
+            "source_zone_id": "d2864b8e-56fb-4945-b69f-6d424fa5b248",
+            "destination_zone_id": "5888bc93-aaae-4242-ae2f-2050d76211fd",
+            "allow_return_traffic": false,
+            "connection_states": ["NEW"],
+            "dst_ip": ["10.0.40.10"],
+            "dst_port": ["80"]
+        }))
+        .expect("shorthand fields should deserialize");
+
+        assert_eq!(req.dst_ip.as_deref(), Some(&["10.0.40.10".to_owned()][..]));
+        assert_eq!(req.dst_port.as_deref(), Some(&["80".to_owned()][..]));
+        // Filter fields should still be None — resolution happens later
+        assert!(req.destination_filter.is_none());
+    }
+
+    /// Shorthand fields must not leak into serialized output (they are
+    /// internal to --from-file and should never reach the API wire format).
+    #[test]
+    fn create_firewall_policy_shorthand_fields_skip_serializing() {
+        let req: CreateFirewallPolicyRequest = serde_json::from_value(serde_json::json!({
+            "name": "Test",
+            "action": "Block",
+            "source_zone_id": "aaa",
+            "destination_zone_id": "bbb",
+            "dst_ip": ["10.0.0.1"]
+        }))
+        .expect("should deserialize");
+
+        let value = serde_json::to_value(&req).expect("should serialize");
+        assert!(value.get("dst_ip").is_none(), "dst_ip must not serialize");
+        assert!(
+            value.get("dst_port").is_none(),
+            "dst_port must not serialize"
+        );
+        assert!(value.get("src_ip").is_none(), "src_ip must not serialize");
+    }
+
+    /// The existing source_filter / destination_filter path must still work
+    /// for users who write the full TrafficFilterSpec in their JSON files.
+    #[test]
+    fn create_firewall_policy_full_filter_spec_still_works() {
+        let req: CreateFirewallPolicyRequest = serde_json::from_value(serde_json::json!({
+            "name": "Full filter",
+            "action": "Allow",
+            "source_zone_id": "aaa",
+            "destination_zone_id": "bbb",
+            "destination_filter": {
+                "type": "ip_address",
+                "addresses": ["10.0.40.10"],
+                "match_opposite": false
+            }
+        }))
+        .expect("full filter spec should deserialize");
+
+        assert!(req.destination_filter.is_some());
+        assert!(req.dst_ip.is_none());
+    }
+
+    /// dst_ip + dst_port should combine into IpAddress filter with nested ports
+    #[test]
+    fn resolve_filters_combines_dst_ip_and_dst_port() {
+        let mut req: CreateFirewallPolicyRequest = serde_json::from_value(serde_json::json!({
+            "name": "Allow Awair",
+            "action": "Allow",
+            "source_zone_id": "d2864b8e-56fb-4945-b69f-6d424fa5b248",
+            "destination_zone_id": "5888bc93-aaae-4242-ae2f-2050d76211fd",
+            "dst_ip": ["10.0.40.10"],
+            "dst_port": ["80"]
+        }))
+        .expect("should deserialize");
+
+        req.resolve_filters().expect("ip + port should be allowed");
+        match &req.destination_filter {
+            Some(TrafficFilterSpec::IpAddress {
+                addresses, ports, ..
+            }) => {
+                assert_eq!(addresses, &["10.0.40.10"]);
+                let Some(PortSpec::Values { items, .. }) = ports else {
+                    panic!("expected PortSpec::Values, got {ports:?}")
+                };
+                assert_eq!(items, &["80"]);
+            }
+            other => panic!("expected IpAddress filter with ports, got {other:?}"),
+        }
+    }
+
+    /// dst_network + dst_ip is still invalid (two primary filter types)
+    #[test]
+    fn resolve_filters_rejects_network_plus_ip() {
+        let mut req: CreateFirewallPolicyRequest = serde_json::from_value(serde_json::json!({
+            "name": "Conflict",
+            "action": "Block",
+            "source_zone_id": "aaa",
+            "destination_zone_id": "bbb",
+            "dst_network": ["net-uuid"],
+            "dst_ip": ["10.0.0.1"]
+        }))
+        .expect("should deserialize");
+
+        assert!(req.resolve_filters().is_err());
+    }
+
+    #[test]
+    fn resolve_filters_converts_dst_ip_only() {
+        let mut req: CreateFirewallPolicyRequest = serde_json::from_value(serde_json::json!({
+            "name": "Allow Awair",
+            "action": "Allow",
+            "source_zone_id": "aaa",
+            "destination_zone_id": "bbb",
+            "dst_ip": ["10.0.40.10"]
+        }))
+        .expect("should deserialize");
+
+        req.resolve_filters().expect("should resolve");
+        match &req.destination_filter {
+            Some(TrafficFilterSpec::IpAddress { addresses, .. }) => {
+                assert_eq!(addresses, &["10.0.40.10"]);
+            }
+            other => panic!("expected IpAddress filter, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn resolve_filters_rejects_shorthand_plus_full_filter() {
+        let mut req: CreateFirewallPolicyRequest = serde_json::from_value(serde_json::json!({
+            "name": "Conflict",
+            "action": "Block",
+            "source_zone_id": "aaa",
+            "destination_zone_id": "bbb",
+            "dst_ip": ["10.0.0.1"],
+            "destination_filter": {
+                "type": "ip_address",
+                "addresses": ["10.0.0.2"]
+            }
+        }))
+        .expect("should deserialize");
+
+        let err = req.resolve_filters().expect_err("should conflict");
+        assert!(err.contains("cannot combine"), "got: {err}");
+    }
+
+    #[test]
+    fn resolve_filters_update_request_works() {
+        let mut req: UpdateFirewallPolicyRequest = serde_json::from_value(serde_json::json!({
+            "dst_port": ["443", "8443"]
+        }))
+        .expect("should deserialize");
+
+        req.resolve_filters().expect("should resolve");
+        let Some(TrafficFilterSpec::Port {
+            ports: PortSpec::Values { items, .. },
+        }) = &req.destination_filter
+        else {
+            panic!(
+                "expected Port filter with values, got {:?}",
+                req.destination_filter
+            )
+        };
+        assert_eq!(items, &["443", "8443"]);
+    }
+
+    /// Pre-PortSpec JSON files used a flat `Vec<String>` for `Port.ports`
+    /// with `match_opposite` at the variant level. The new schema nests
+    /// both inside `PortSpec`, but the deserializer must still accept the
+    /// legacy shape so existing payloads keep working.
+    #[test]
+    fn destination_filter_accepts_legacy_port_variant_shape() {
+        let req: CreateFirewallPolicyRequest = serde_json::from_value(serde_json::json!({
+            "name": "Block port 80",
+            "action": "Block",
+            "source_zone_id": "d2864b8e-56fb-4945-b69f-6d424fa5b248",
+            "destination_zone_id": "5888bc93-aaae-4242-ae2f-2050d76211fd",
+            "destination_filter": {
+                "type": "port",
+                "ports": ["80"],
+                "match_opposite": true
+            }
+        }))
+        .expect("legacy port shape should still deserialize");
+
+        let Some(TrafficFilterSpec::Port {
+            ports:
+                PortSpec::Values {
+                    items,
+                    match_opposite,
+                },
+        }) = &req.destination_filter
+        else {
+            panic!(
+                "expected Port with PortSpec::Values, got {:?}",
+                req.destination_filter
+            )
+        };
+        assert_eq!(items, &["80"]);
+        // Legacy outer match_opposite is folded into the inner PortSpec.
+        assert!(*match_opposite);
+    }
+
+    /// Tagged PortSpec::MatchingList round-trips from JSON as a sibling of
+    /// addresses (the shape PR 2's group resolver emits and what users will
+    /// hand-write for direct group-uuid references).
+    #[test]
+    fn destination_filter_accepts_ip_address_with_port_matching_list() {
+        let mut req: CreateFirewallPolicyRequest = serde_json::from_value(serde_json::json!({
+            "name": "Apple Companion Link",
+            "action": "Allow",
+            "source_zone_id": "d2864b8e-56fb-4945-b69f-6d424fa5b248",
+            "destination_zone_id": "5888bc93-aaae-4242-ae2f-2050d76211fd",
+            "destination_filter": {
+                "type": "ip_address",
+                "addresses": ["10.0.10.2", "10.0.10.4"],
+                "ports": {
+                    "type": "matching_list",
+                    "list_id": "24740a56-9cb9-4890-a5ac-589d30914a55"
+                }
+            }
+        }))
+        .expect("ip_address + port matching_list should deserialize");
+
+        req.resolve_filters().expect("no shorthand, no-op");
+
+        let Some(TrafficFilterSpec::IpAddress {
+            addresses,
+            ports: Some(PortSpec::MatchingList { list_id, .. }),
+            ..
+        }) = &req.destination_filter
+        else {
+            panic!(
+                "expected IpAddress with PortSpec::MatchingList, got {:?}",
+                req.destination_filter
+            )
+        };
+        assert_eq!(addresses, &["10.0.10.2", "10.0.10.4"]);
+        assert_eq!(list_id, "24740a56-9cb9-4890-a5ac-589d30914a55");
+    }
 
     #[test]
     fn create_acl_rule_request_defaults_rule_type() {

--- a/crates/unifly-api/src/command/requests/policy.rs
+++ b/crates/unifly-api/src/command/requests/policy.rs
@@ -13,7 +13,7 @@ pub struct CreateFirewallPolicyRequest {
     pub destination_zone_id: EntityId,
     #[serde(default = "default_true")]
     pub enabled: bool,
-    #[serde(default)]
+    #[serde(default, alias = "logging")]
     pub logging_enabled: bool,
     #[serde(default = "default_true")]
     pub allow_return_traffic: bool,
@@ -67,7 +67,7 @@ pub struct UpdateFirewallPolicyRequest {
     pub source_filter: Option<TrafficFilterSpec>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub destination_filter: Option<TrafficFilterSpec>,
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(skip_serializing_if = "Option::is_none", alias = "logging")]
     pub logging_enabled: Option<bool>,
 
     // Shorthand fields for --from-file convenience (map to source/destination_filter)

--- a/crates/unifly-api/src/controller/commands/policy/firewall.rs
+++ b/crates/unifly-api/src/controller/commands/policy/firewall.rs
@@ -14,7 +14,7 @@ pub(super) async fn route(ctx: &CommandContext, cmd: Command) -> Result<CommandR
             let (ic, sid) = require_integration(integration, site_id, "CreateFirewallPolicy")?;
             let action_str = match req.action {
                 FirewallAction::Allow => "ALLOW",
-                FirewallAction::Block => "DROP",
+                FirewallAction::Block => "BLOCK",
                 FirewallAction::Reject => "REJECT",
             };
             let source =
@@ -24,11 +24,16 @@ pub(super) async fn route(ctx: &CommandContext, cmd: Command) -> Result<CommandR
                 req.destination_filter.as_ref(),
             );
             let ip_version = req.ip_version.as_deref().unwrap_or("IPV4_AND_IPV6");
+            let action = if req.action == FirewallAction::Allow {
+                serde_json::json!({ "type": action_str, "allowReturnTraffic": req.allow_return_traffic })
+            } else {
+                serde_json::json!({ "type": action_str })
+            };
             let body = crate::integration_types::FirewallPolicyCreateUpdate {
                 name: req.name,
                 description: req.description,
                 enabled: req.enabled,
-                action: serde_json::json!({ "type": action_str, "allowReturnTraffic": req.allow_return_traffic }),
+                action,
                 source,
                 destination,
                 ip_protocol_scope: serde_json::json!({ "ipVersion": ip_version }),
@@ -72,32 +77,45 @@ pub(super) async fn route(ctx: &CommandContext, cmd: Command) -> Result<CommandR
             };
 
             let action = if update.action.is_some() || update.allow_return_traffic.is_some() {
-                let action_type = update.action.map_or_else(
-                    || {
+                // Determine the action type to send. If the user supplied
+                // `update.action`, use it. Otherwise inspect the existing
+                // policy's wire-level action type and pass it through —
+                // including `DROP` (the legacy block alias from older
+                // unifly versions, normalized to `BLOCK` here) and any
+                // other unrecognized type. Falling back to `ALLOW` would
+                // silently turn a block rule into an allow rule.
+                let action_type: String = if let Some(action) = update.action {
+                    match action {
+                        FirewallAction::Allow => "ALLOW",
+                        FirewallAction::Block => "BLOCK",
+                        FirewallAction::Reject => "REJECT",
+                    }
+                    .to_owned()
+                } else {
+                    let existing_type = existing
+                        .action
+                        .get("type")
+                        .and_then(|v| v.as_str())
+                        .unwrap_or("ALLOW");
+                    if existing_type == "DROP" {
+                        "BLOCK".to_owned()
+                    } else {
+                        existing_type.to_owned()
+                    }
+                };
+
+                if action_type == "ALLOW" {
+                    let allow_return = update.allow_return_traffic.unwrap_or_else(|| {
                         existing
                             .action
-                            .get("type")
-                            .and_then(|v| v.as_str())
-                            .unwrap_or("ALLOW")
-                            .to_owned()
-                    },
-                    |a| {
-                        match a {
-                            FirewallAction::Allow => "ALLOW",
-                            FirewallAction::Block => "DROP",
-                            FirewallAction::Reject => "REJECT",
-                        }
-                        .to_owned()
-                    },
-                );
-                let allow_return = update.allow_return_traffic.unwrap_or_else(|| {
-                    existing
-                        .action
-                        .get("allowReturnTraffic")
-                        .and_then(serde_json::Value::as_bool)
-                        .unwrap_or(true)
-                });
-                serde_json::json!({ "type": action_type, "allowReturnTraffic": allow_return })
+                            .get("allowReturnTraffic")
+                            .and_then(serde_json::Value::as_bool)
+                            .unwrap_or(true)
+                    });
+                    serde_json::json!({ "type": action_type, "allowReturnTraffic": allow_return })
+                } else {
+                    serde_json::json!({ "type": action_type })
+                }
             } else {
                 existing.action
             };

--- a/crates/unifly-api/src/controller/commands/policy/firewall.rs
+++ b/crates/unifly-api/src/controller/commands/policy/firewall.rs
@@ -165,24 +165,19 @@ pub(super) async fn route(ctx: &CommandContext, cmd: Command) -> Result<CommandR
         }
         Command::ReorderFirewallPolicies {
             zone_pair,
-            ordered_ids,
-            after_system,
+            before_system_ids,
+            after_system_ids,
         } => {
             let (ic, sid) = require_integration(integration, site_id, "ReorderFirewallPolicies")?;
             let source_zone_uuid = require_uuid(&zone_pair.0)?;
             let destination_zone_uuid = require_uuid(&zone_pair.1)?;
-            let uuids: Result<Vec<uuid::Uuid>, _> = ordered_ids.iter().map(require_uuid).collect();
-            let uuids = uuids?;
-            let body = if after_system {
-                crate::integration_types::FirewallPolicyOrdering {
-                    before_system_defined: Vec::new(),
-                    after_system_defined: uuids,
-                }
-            } else {
-                crate::integration_types::FirewallPolicyOrdering {
-                    before_system_defined: uuids,
-                    after_system_defined: Vec::new(),
-                }
+            let before: Result<Vec<uuid::Uuid>, _> =
+                before_system_ids.iter().map(require_uuid).collect();
+            let after: Result<Vec<uuid::Uuid>, _> =
+                after_system_ids.iter().map(require_uuid).collect();
+            let body = crate::integration_types::FirewallPolicyOrdering {
+                before_system_defined: before?,
+                after_system_defined: after?,
             };
             ic.set_firewall_policy_ordering(&sid, &source_zone_uuid, &destination_zone_uuid, &body)
                 .await?;

--- a/crates/unifly-api/src/controller/commands/policy/firewall.rs
+++ b/crates/unifly-api/src/controller/commands/policy/firewall.rs
@@ -18,11 +18,11 @@ pub(super) async fn route(ctx: &CommandContext, cmd: Command) -> Result<CommandR
                 FirewallAction::Reject => "REJECT",
             };
             let source =
-                build_endpoint_json(&req.source_zone_id.to_string(), req.source_filter.as_ref());
+                build_endpoint_json(&req.source_zone_id.to_string(), req.source_filter.as_ref())?;
             let destination = build_endpoint_json(
                 &req.destination_zone_id.to_string(),
                 req.destination_filter.as_ref(),
-            );
+            )?;
             let ip_version = req.ip_version.as_deref().unwrap_or("IPV4_AND_IPV6");
             let action = if req.action == FirewallAction::Allow {
                 serde_json::json!({ "type": action_str, "allowReturnTraffic": req.allow_return_traffic })
@@ -59,7 +59,7 @@ pub(super) async fn route(ctx: &CommandContext, cmd: Command) -> Result<CommandR
                     .and_then(|s| s.zone_id)
                     .map(|u| u.to_string())
                     .unwrap_or_default();
-                build_endpoint_json(&zone_id, Some(spec))
+                build_endpoint_json(&zone_id, Some(spec))?
             } else {
                 serde_json::to_value(&existing.source).unwrap_or_default()
             };
@@ -71,7 +71,7 @@ pub(super) async fn route(ctx: &CommandContext, cmd: Command) -> Result<CommandR
                     .and_then(|d| d.zone_id)
                     .map(|u| u.to_string())
                     .unwrap_or_default();
-                build_endpoint_json(&zone_id, Some(spec))
+                build_endpoint_json(&zone_id, Some(spec))?
             } else {
                 serde_json::to_value(&existing.destination).unwrap_or_default()
             };

--- a/crates/unifly-api/src/controller/commands/policy/firewall.rs
+++ b/crates/unifly-api/src/controller/commands/policy/firewall.rs
@@ -76,48 +76,42 @@ pub(super) async fn route(ctx: &CommandContext, cmd: Command) -> Result<CommandR
                 serde_json::to_value(&existing.destination).unwrap_or_default()
             };
 
-            let action = if update.action.is_some() || update.allow_return_traffic.is_some() {
-                // Determine the action type to send. If the user supplied
-                // `update.action`, use it. Otherwise inspect the existing
-                // policy's wire-level action type and pass it through —
-                // including `DROP` (the legacy block alias from older
-                // unifly versions, normalized to `BLOCK` here) and any
-                // other unrecognized type. Falling back to `ALLOW` would
-                // silently turn a block rule into an allow rule.
-                let action_type: String = if let Some(action) = update.action {
-                    match action {
-                        FirewallAction::Allow => "ALLOW",
-                        FirewallAction::Block => "BLOCK",
-                        FirewallAction::Reject => "REJECT",
-                    }
-                    .to_owned()
-                } else {
-                    let existing_type = existing
-                        .action
-                        .get("type")
-                        .and_then(|v| v.as_str())
-                        .unwrap_or("ALLOW");
-                    if existing_type == "DROP" {
-                        "BLOCK".to_owned()
-                    } else {
-                        existing_type.to_owned()
-                    }
-                };
-
-                if action_type == "ALLOW" {
-                    let allow_return = update.allow_return_traffic.unwrap_or_else(|| {
-                        existing
-                            .action
-                            .get("allowReturnTraffic")
-                            .and_then(serde_json::Value::as_bool)
-                            .unwrap_or(true)
-                    });
-                    serde_json::json!({ "type": action_type, "allowReturnTraffic": allow_return })
-                } else {
-                    serde_json::json!({ "type": action_type })
+            // Always reconstruct the action payload so that legacy `DROP`
+            // values from older unifly versions are normalized to `BLOCK`
+            // even when the caller did not touch the action field. Echoing
+            // back `existing.action` verbatim would re-send `DROP`, which
+            // the integration API rejects.
+            let action_type: String = if let Some(action) = update.action {
+                match action {
+                    FirewallAction::Allow => "ALLOW",
+                    FirewallAction::Block => "BLOCK",
+                    FirewallAction::Reject => "REJECT",
                 }
+                .to_owned()
             } else {
-                existing.action
+                let existing_type = existing
+                    .action
+                    .get("type")
+                    .and_then(|v| v.as_str())
+                    .unwrap_or("ALLOW");
+                if existing_type == "DROP" {
+                    "BLOCK".to_owned()
+                } else {
+                    existing_type.to_owned()
+                }
+            };
+
+            let action = if action_type == "ALLOW" {
+                let allow_return = update.allow_return_traffic.unwrap_or_else(|| {
+                    existing
+                        .action
+                        .get("allowReturnTraffic")
+                        .and_then(serde_json::Value::as_bool)
+                        .unwrap_or(true)
+                });
+                serde_json::json!({ "type": action_type, "allowReturnTraffic": allow_return })
+            } else {
+                serde_json::json!({ "type": action_type })
             };
 
             let ip_protocol_scope = if let Some(ref version) = update.ip_version {

--- a/crates/unifly-api/src/controller/commands/policy/firewall.rs
+++ b/crates/unifly-api/src/controller/commands/policy/firewall.rs
@@ -37,8 +37,10 @@ pub(super) async fn route(ctx: &CommandContext, cmd: Command) -> Result<CommandR
                 schedule: None,
                 connection_state_filter: req.connection_states,
             };
-            ic.create_firewall_policy(&sid, &body).await?;
-            Ok(CommandResult::Ok)
+            let resp = ic.create_firewall_policy(&sid, &body).await?;
+            Ok(CommandResult::CreatedId(crate::model::EntityId::Uuid(
+                resp.id,
+            )))
         }
         Command::UpdateFirewallPolicy { id, update } => {
             let (ic, sid) = require_integration(integration, site_id, "UpdateFirewallPolicy")?;

--- a/crates/unifly-api/src/controller/commands/policy/firewall.rs
+++ b/crates/unifly-api/src/controller/commands/policy/firewall.rs
@@ -89,11 +89,17 @@ pub(super) async fn route(ctx: &CommandContext, cmd: Command) -> Result<CommandR
                 }
                 .to_owned()
             } else {
+                // Refuse to default to ALLOW if the controller's stored
+                // action shape is unrecognizable. A silent fallback would
+                // promote a Block/Reject policy to Allow on any field-only
+                // update, which is a security-relevant mutation.
                 let existing_type = existing
                     .action
                     .get("type")
                     .and_then(|v| v.as_str())
-                    .unwrap_or("ALLOW");
+                    .ok_or_else(|| CoreError::ValidationFailed {
+                        message: "existing firewall policy has no recognizable action type; specify --action explicitly".into(),
+                    })?;
                 if existing_type == "DROP" {
                     "BLOCK".to_owned()
                 } else {

--- a/crates/unifly-api/src/controller/payloads/traffic.rs
+++ b/crates/unifly-api/src/controller/payloads/traffic.rs
@@ -1,6 +1,31 @@
 use crate::command::requests::{PortSpec, TrafficFilterSpec};
+use crate::core_error::CoreError;
 
-fn build_port_filter_json(spec: &PortSpec) -> serde_json::Value {
+fn parse_port(value: &str) -> Result<u16, CoreError> {
+    value.parse::<u16>().map_err(|_| CoreError::ValidationFailed {
+        message: format!("invalid port number {value:?} (expected 0-65535)"),
+    })
+}
+
+fn build_port_item_json(p: &str) -> Result<serde_json::Value, CoreError> {
+    if p.contains('-') {
+        let mut parts = p.splitn(2, '-');
+        let start_str = parts.next().unwrap_or("");
+        let end_str = parts.next().unwrap_or("");
+        let start = parse_port(start_str)?;
+        let end = parse_port(end_str)?;
+        Ok(serde_json::json!({
+            "type": "PORT_NUMBER_RANGE",
+            "startPort": start,
+            "endPort": end,
+        }))
+    } else {
+        let port = parse_port(p)?;
+        Ok(serde_json::json!({ "type": "PORT_NUMBER", "value": port }))
+    }
+}
+
+fn build_port_filter_json(spec: &PortSpec) -> Result<serde_json::Value, CoreError> {
     match spec {
         PortSpec::Values {
             items,
@@ -8,43 +33,29 @@ fn build_port_filter_json(spec: &PortSpec) -> serde_json::Value {
         } => {
             let json_items: Vec<serde_json::Value> = items
                 .iter()
-                .map(|p| {
-                    if p.contains('-') {
-                        let range: Vec<&str> = p.splitn(2, '-').collect();
-                        let start: u16 = range[0].parse().unwrap_or(0);
-                        let end: u16 = range.get(1).unwrap_or(&"0").parse().unwrap_or(0);
-                        serde_json::json!({
-                            "type": "PORT_NUMBER_RANGE",
-                            "startPort": start,
-                            "endPort": end,
-                        })
-                    } else {
-                        let port: u16 = p.parse().unwrap_or(0);
-                        serde_json::json!({ "type": "PORT_NUMBER", "value": port })
-                    }
-                })
-                .collect();
-            serde_json::json!({
+                .map(|p| build_port_item_json(p))
+                .collect::<Result<_, _>>()?;
+            Ok(serde_json::json!({
                 "type": "PORTS",
                 "items": json_items,
                 "matchOpposite": match_opposite,
-            })
+            }))
         }
         PortSpec::MatchingList {
             list_id,
             match_opposite,
-        } => serde_json::json!({
+        } => Ok(serde_json::json!({
             "type": "TRAFFIC_MATCHING_LIST",
             "trafficMatchingListId": list_id,
             "matchOpposite": match_opposite,
-        }),
+        })),
     }
 }
 
 pub(in super::super) fn build_endpoint_json(
     zone_id: &str,
     filter: Option<&TrafficFilterSpec>,
-) -> serde_json::Value {
+) -> Result<serde_json::Value, CoreError> {
     let mut obj = serde_json::json!({ "zoneId": zone_id });
 
     if let Some(spec) = filter {
@@ -64,7 +75,7 @@ pub(in super::super) fn build_endpoint_json(
                 if let Some(ports) = ports {
                     v.as_object_mut()
                         .expect("json! produces object")
-                        .insert("portFilter".into(), build_port_filter_json(ports));
+                        .insert("portFilter".into(), build_port_filter_json(ports)?);
                 }
                 v
             }
@@ -97,13 +108,13 @@ pub(in super::super) fn build_endpoint_json(
                 if let Some(ports) = ports {
                     v.as_object_mut()
                         .expect("json! produces object")
-                        .insert("portFilter".into(), build_port_filter_json(ports));
+                        .insert("portFilter".into(), build_port_filter_json(ports)?);
                 }
                 v
             }
             TrafficFilterSpec::Port { ports } => serde_json::json!({
                 "type": "PORT",
-                "portFilter": build_port_filter_json(ports),
+                "portFilter": build_port_filter_json(ports)?,
             }),
         };
         obj.as_object_mut()
@@ -111,7 +122,7 @@ pub(in super::super) fn build_endpoint_json(
             .insert("trafficFilter".into(), traffic_filter);
     }
 
-    obj
+    Ok(obj)
 }
 
 pub(in super::super) fn traffic_matching_list_items(
@@ -134,6 +145,7 @@ pub(in super::super) fn traffic_matching_list_items(
 mod tests {
     use super::{build_endpoint_json, traffic_matching_list_items};
     use crate::command::requests::{PortSpec, TrafficFilterSpec};
+    use crate::core_error::CoreError;
     use serde_json::json;
 
     #[test]
@@ -153,7 +165,7 @@ mod tests {
                 match_opposite: false,
             }),
         };
-        let result = build_endpoint_json("zone-uuid", Some(&spec));
+        let result = build_endpoint_json("zone-uuid", Some(&spec)).expect("build endpoint json");
         let tf = result.get("trafficFilter").expect("trafficFilter present");
         assert_eq!(tf.get("type").and_then(|v| v.as_str()), Some("IP_ADDRESS"));
         // ipAddressFilter should be present
@@ -186,9 +198,32 @@ mod tests {
             match_opposite: false,
             ports: None,
         };
-        let result = build_endpoint_json("zone-uuid", Some(&spec));
+        let result = build_endpoint_json("zone-uuid", Some(&spec)).expect("build endpoint json");
         let tf = result.get("trafficFilter").expect("trafficFilter present");
         assert!(tf.get("portFilter").is_none());
+    }
+
+    #[test]
+    fn build_port_filter_json_rejects_invalid_port_number() {
+        let spec = PortSpec::Values {
+            items: vec!["abc".into()],
+            match_opposite: false,
+        };
+        let err = super::build_port_filter_json(&spec).expect_err("invalid port should error");
+        assert!(
+            matches!(err, CoreError::ValidationFailed { .. }),
+            "expected ValidationFailed, got {err:?}",
+        );
+    }
+
+    #[test]
+    fn build_port_filter_json_rejects_invalid_port_range() {
+        let spec = PortSpec::Values {
+            items: vec!["80-abc".into()],
+            match_opposite: false,
+        };
+        let err = super::build_port_filter_json(&spec).expect_err("invalid range end should error");
+        assert!(matches!(err, CoreError::ValidationFailed { .. }));
     }
 
     /// Full round-trip: a JSONC-style payload using the new tagged PortSpec
@@ -219,7 +254,8 @@ mod tests {
         let wire = build_endpoint_json(
             "5888bc93-aaae-4242-ae2f-2050d76211fd",
             req.destination_filter.as_ref(),
-        );
+        )
+        .expect("build endpoint json");
 
         // Print so `cargo test -- --nocapture` shows the wire shape.
         eprintln!(
@@ -248,7 +284,7 @@ mod tests {
                 match_opposite: false,
             }),
         };
-        let result = build_endpoint_json("zone-uuid", Some(&spec));
+        let result = build_endpoint_json("zone-uuid", Some(&spec)).expect("build endpoint json");
         let port_filter = result["trafficFilter"]
             .get("portFilter")
             .expect("portFilter present");

--- a/crates/unifly-api/src/controller/payloads/traffic.rs
+++ b/crates/unifly-api/src/controller/payloads/traffic.rs
@@ -2,9 +2,11 @@ use crate::command::requests::{PortSpec, TrafficFilterSpec};
 use crate::core_error::CoreError;
 
 fn parse_port(value: &str) -> Result<u16, CoreError> {
-    value.parse::<u16>().map_err(|_| CoreError::ValidationFailed {
-        message: format!("invalid port number {value:?} (expected 0-65535)"),
-    })
+    value
+        .parse::<u16>()
+        .map_err(|_| CoreError::ValidationFailed {
+            message: format!("invalid port number {value:?} (expected 0-65535)"),
+        })
 }
 
 fn build_port_item_json(p: &str) -> Result<serde_json::Value, CoreError> {

--- a/crates/unifly-api/src/controller/payloads/traffic.rs
+++ b/crates/unifly-api/src/controller/payloads/traffic.rs
@@ -1,4 +1,45 @@
-use crate::command::requests::TrafficFilterSpec;
+use crate::command::requests::{PortSpec, TrafficFilterSpec};
+
+fn build_port_filter_json(spec: &PortSpec) -> serde_json::Value {
+    match spec {
+        PortSpec::Values {
+            items,
+            match_opposite,
+        } => {
+            let json_items: Vec<serde_json::Value> = items
+                .iter()
+                .map(|p| {
+                    if p.contains('-') {
+                        let range: Vec<&str> = p.splitn(2, '-').collect();
+                        let start: u16 = range[0].parse().unwrap_or(0);
+                        let end: u16 = range.get(1).unwrap_or(&"0").parse().unwrap_or(0);
+                        serde_json::json!({
+                            "type": "PORT_NUMBER_RANGE",
+                            "startPort": start,
+                            "endPort": end,
+                        })
+                    } else {
+                        let port: u16 = p.parse().unwrap_or(0);
+                        serde_json::json!({ "type": "PORT_NUMBER", "value": port })
+                    }
+                })
+                .collect();
+            serde_json::json!({
+                "type": "PORTS",
+                "items": json_items,
+                "matchOpposite": match_opposite,
+            })
+        }
+        PortSpec::MatchingList {
+            list_id,
+            match_opposite,
+        } => serde_json::json!({
+            "type": "TRAFFIC_MATCHING_LIST",
+            "trafficMatchingListId": list_id,
+            "matchOpposite": match_opposite,
+        }),
+    }
+}
 
 pub(in super::super) fn build_endpoint_json(
     zone_id: &str,
@@ -11,18 +52,26 @@ pub(in super::super) fn build_endpoint_json(
             TrafficFilterSpec::Network {
                 network_ids,
                 match_opposite,
+                ports,
             } => {
-                serde_json::json!({
+                let mut v = serde_json::json!({
                     "type": "NETWORK",
                     "networkFilter": {
                         "networkIds": network_ids,
                         "matchOpposite": match_opposite,
                     }
-                })
+                });
+                if let Some(ports) = ports {
+                    v.as_object_mut()
+                        .expect("json! produces object")
+                        .insert("portFilter".into(), build_port_filter_json(ports));
+                }
+                v
             }
             TrafficFilterSpec::IpAddress {
                 addresses,
                 match_opposite,
+                ports,
             } => {
                 let items: Vec<serde_json::Value> = addresses
                     .iter()
@@ -37,42 +86,25 @@ pub(in super::super) fn build_endpoint_json(
                         }
                     })
                     .collect();
-                serde_json::json!({
-                    "type": "IP_ADDRESSES",
+                let mut v = serde_json::json!({
+                    "type": "IP_ADDRESS",
                     "ipAddressFilter": {
                         "type": "IP_ADDRESSES",
                         "items": items,
                         "matchOpposite": match_opposite,
                     }
-                })
+                });
+                if let Some(ports) = ports {
+                    v.as_object_mut()
+                        .expect("json! produces object")
+                        .insert("portFilter".into(), build_port_filter_json(ports));
+                }
+                v
             }
-            TrafficFilterSpec::Port {
-                ports,
-                match_opposite,
-            } => {
-                let items: Vec<serde_json::Value> = ports
-                    .iter()
-                    .map(|p| {
-                        if p.contains('-') {
-                            let parts: Vec<&str> = p.splitn(2, '-').collect();
-                            let start: u16 = parts[0].parse().unwrap_or(0);
-                            let end: u16 = parts.get(1).unwrap_or(&"0").parse().unwrap_or(0);
-                            serde_json::json!({ "type": "PORT_RANGE", "startPort": start, "endPort": end })
-                        } else {
-                            let port: u16 = p.parse().unwrap_or(0);
-                            serde_json::json!({ "type": "PORT_NUMBER", "value": port })
-                        }
-                    })
-                    .collect();
-                serde_json::json!({
-                    "type": "PORT",
-                    "portFilter": {
-                        "type": "PORTS",
-                        "items": items,
-                        "matchOpposite": match_opposite,
-                    }
-                })
-            }
+            TrafficFilterSpec::Port { ports } => serde_json::json!({
+                "type": "PORT",
+                "portFilter": build_port_filter_json(ports),
+            }),
         };
         obj.as_object_mut()
             .expect("json! produces object")
@@ -100,7 +132,8 @@ pub(in super::super) fn traffic_matching_list_items(
 
 #[cfg(test)]
 mod tests {
-    use super::traffic_matching_list_items;
+    use super::{build_endpoint_json, traffic_matching_list_items};
+    use crate::command::requests::{PortSpec, TrafficFilterSpec};
     use serde_json::json;
 
     #[test]
@@ -108,5 +141,121 @@ mod tests {
         let raw_items = [json!({"type": "PORT_NUMBER", "value": 443})];
         let items = traffic_matching_list_items(&["80".into()], Some(&raw_items));
         assert_eq!(items, vec![json!({"type": "PORT_NUMBER", "value": 443})]);
+    }
+
+    #[test]
+    fn build_endpoint_json_ip_with_port_nests_port_filter() {
+        let spec = TrafficFilterSpec::IpAddress {
+            addresses: vec!["10.0.40.10".into()],
+            match_opposite: false,
+            ports: Some(PortSpec::Values {
+                items: vec!["80".into()],
+                match_opposite: false,
+            }),
+        };
+        let result = build_endpoint_json("zone-uuid", Some(&spec));
+        let tf = result.get("trafficFilter").expect("trafficFilter present");
+        assert_eq!(tf.get("type").and_then(|v| v.as_str()), Some("IP_ADDRESS"));
+        // ipAddressFilter should be present
+        let ip_filter = tf.get("ipAddressFilter").expect("ipAddressFilter present");
+        assert_eq!(
+            ip_filter
+                .get("items")
+                .and_then(|v| v.as_array())
+                .map(Vec::len),
+            Some(1)
+        );
+        // portFilter should be nested alongside ipAddressFilter
+        let port_filter = tf.get("portFilter").expect("portFilter present");
+        assert_eq!(
+            port_filter
+                .get("items")
+                .and_then(|v| v.as_array())
+                .map(Vec::len),
+            Some(1)
+        );
+        let port_item = &port_filter["items"][0];
+        assert_eq!(port_item["type"].as_str(), Some("PORT_NUMBER"));
+        assert_eq!(port_item["value"].as_u64(), Some(80));
+    }
+
+    #[test]
+    fn build_endpoint_json_ip_without_port_omits_port_filter() {
+        let spec = TrafficFilterSpec::IpAddress {
+            addresses: vec!["10.0.0.1".into()],
+            match_opposite: false,
+            ports: None,
+        };
+        let result = build_endpoint_json("zone-uuid", Some(&spec));
+        let tf = result.get("trafficFilter").expect("trafficFilter present");
+        assert!(tf.get("portFilter").is_none());
+    }
+
+    /// Full round-trip: a JSONC-style payload using the new tagged PortSpec
+    /// shape deserializes into the request, then the payload builder emits
+    /// the matching wire JSON. Demonstrates the schema is consistent across
+    /// from-file → in-memory → wire.
+    #[test]
+    fn full_roundtrip_ip_address_with_port_matching_list() {
+        use crate::command::requests::CreateFirewallPolicyRequest;
+
+        let mut req: CreateFirewallPolicyRequest = serde_json::from_value(json!({
+            "name": "Apple Companion Link",
+            "action": "Allow",
+            "source_zone_id": "d2864b8e-56fb-4945-b69f-6d424fa5b248",
+            "destination_zone_id": "5888bc93-aaae-4242-ae2f-2050d76211fd",
+            "destination_filter": {
+                "type": "ip_address",
+                "addresses": ["10.0.10.2"],
+                "ports": {
+                    "type": "matching_list",
+                    "list_id": "companion-link-ports-uuid"
+                }
+            }
+        }))
+        .expect("deserialize");
+        req.resolve_filters().expect("resolve");
+
+        let wire = build_endpoint_json(
+            "5888bc93-aaae-4242-ae2f-2050d76211fd",
+            req.destination_filter.as_ref(),
+        );
+
+        // Print so `cargo test -- --nocapture` shows the wire shape.
+        eprintln!(
+            "wire payload:\n{}",
+            serde_json::to_string_pretty(&wire).expect("serializing test wire payload"),
+        );
+
+        assert_eq!(wire["trafficFilter"]["type"].as_str(), Some("IP_ADDRESS"));
+        assert_eq!(
+            wire["trafficFilter"]["portFilter"]["type"].as_str(),
+            Some("TRAFFIC_MATCHING_LIST"),
+        );
+        assert_eq!(
+            wire["trafficFilter"]["portFilter"]["trafficMatchingListId"].as_str(),
+            Some("companion-link-ports-uuid"),
+        );
+    }
+
+    #[test]
+    fn build_endpoint_json_ip_with_port_matching_list_emits_traffic_matching_list() {
+        let spec = TrafficFilterSpec::IpAddress {
+            addresses: vec!["10.0.0.5".into()],
+            match_opposite: false,
+            ports: Some(PortSpec::MatchingList {
+                list_id: "24740a56-9cb9-4890-a5ac-589d30914a55".into(),
+                match_opposite: false,
+            }),
+        };
+        let result = build_endpoint_json("zone-uuid", Some(&spec));
+        let port_filter = result["trafficFilter"]
+            .get("portFilter")
+            .expect("portFilter present");
+        assert_eq!(port_filter["type"].as_str(), Some("TRAFFIC_MATCHING_LIST"));
+        assert_eq!(
+            port_filter["trafficMatchingListId"].as_str(),
+            Some("24740a56-9cb9-4890-a5ac-589d30914a55")
+        );
     }
 }

--- a/crates/unifly-api/src/integration/types/policy.rs
+++ b/crates/unifly-api/src/integration/types/policy.rs
@@ -237,7 +237,7 @@ pub enum PortItem {
         #[serde(deserialize_with = "deserialize_port_value")]
         value: String,
     },
-    #[serde(rename = "PORT_RANGE")]
+    #[serde(rename = "PORT_NUMBER_RANGE", alias = "PORT_RANGE")]
     Range {
         #[serde(rename = "startPort", deserialize_with = "deserialize_port_value")]
         start_port: String,
@@ -604,5 +604,41 @@ mod tests {
         .unwrap();
 
         assert!(matches!(filter, IpAddressFilter::Specific { .. }));
+    }
+
+    #[test]
+    fn port_item_range_serializes_as_port_number_range() {
+        let item = PortItem::Range {
+            start_port: "49152".into(),
+            end_port: "65535".into(),
+        };
+        let json = serde_json::to_value(&item).unwrap();
+        assert_eq!(
+            json.get("type").and_then(serde_json::Value::as_str),
+            Some("PORT_NUMBER_RANGE"),
+            "Range must serialize as PORT_NUMBER_RANGE, not PORT_RANGE"
+        );
+        assert_eq!(
+            json.get("startPort").and_then(serde_json::Value::as_str),
+            Some("49152")
+        );
+        assert_eq!(
+            json.get("endPort").and_then(serde_json::Value::as_str),
+            Some("65535")
+        );
+    }
+
+    #[test]
+    fn port_item_range_deserializes_from_port_range_alias() {
+        let item: PortItem = serde_json::from_value(serde_json::json!({
+            "type": "PORT_RANGE",
+            "startPort": "8000",
+            "endPort": "9000"
+        }))
+        .unwrap();
+        assert!(
+            matches!(item, PortItem::Range { .. }),
+            "PORT_RANGE alias must still deserialize"
+        );
     }
 }

--- a/crates/unifly/src/cli/args/firewall.rs
+++ b/crates/unifly/src/cli/args/firewall.rs
@@ -109,6 +109,10 @@ pub enum FirewallPoliciesCommand {
         /// Create from JSON file (complex policies)
         #[arg(long, short = 'F', conflicts_with_all = &["name", "action", "source_zone", "dest_zone"])]
         from_file: Option<PathBuf>,
+
+        /// Place policy after system-defined rules (index ~40000 instead of ~10000)
+        #[arg(long)]
+        after_system: bool,
     },
 
     /// Update a firewall policy

--- a/crates/unifly/src/cli/commands/firewall/policies.rs
+++ b/crates/unifly/src/cli/commands/firewall/policies.rs
@@ -161,35 +161,31 @@ pub(super) async fn handle(
             dst_port,
             states,
             ip_version,
+            after_system,
         } => {
-            let req = if let Some(path) = from_file.as_ref() {
-                serde_json::from_value(util::read_json_file(path)?)?
-            } else {
-                CreateFirewallPolicyRequest {
-                    name: name.unwrap_or_default(),
-                    action: action
-                        .as_ref()
-                        .map_or(unifly_api::model::FirewallAction::Block, map_fw_action),
-                    source_zone_id: EntityId::from(source_zone.unwrap_or_default()),
-                    destination_zone_id: EntityId::from(dest_zone.unwrap_or_default()),
-                    enabled,
-                    logging_enabled: logging,
-                    allow_return_traffic,
-                    description,
-                    ip_version,
-                    connection_states: states,
-                    source_filter: build_filter_spec("src", src_network, src_ip, src_port)?,
-                    destination_filter: build_filter_spec("dst", dst_network, dst_ip, dst_port)?,
-                }
-            };
-
-            controller
-                .execute(CoreCommand::CreateFirewallPolicy(req))
-                .await?;
-            if !global.quiet {
-                eprintln!("Firewall policy created");
-            }
-            Ok(())
+            handle_create(
+                controller,
+                global,
+                from_file,
+                name,
+                action,
+                source_zone,
+                dest_zone,
+                enabled,
+                description,
+                logging,
+                allow_return_traffic,
+                src_network,
+                src_ip,
+                src_port,
+                dst_network,
+                dst_ip,
+                dst_port,
+                states,
+                ip_version,
+                after_system,
+            )
+            .await
         }
 
         FirewallPoliciesCommand::Update {
@@ -205,46 +201,22 @@ pub(super) async fn handle(
             states,
             ip_version,
         } => {
-            if from_file.is_none()
-                && allow_return_traffic.is_none()
-                && src_network.is_none()
-                && src_ip.is_none()
-                && src_port.is_none()
-                && dst_network.is_none()
-                && dst_ip.is_none()
-                && dst_port.is_none()
-                && states.is_none()
-                && ip_version.is_none()
-            {
-                return Err(CliError::Validation {
-                    field: "update".into(),
-                    reason: "at least one update flag or --from-file is required".into(),
-                });
-            }
-
-            let update = if let Some(path) = from_file.as_ref() {
-                serde_json::from_value(util::read_json_file(path)?)?
-            } else {
-                UpdateFirewallPolicyRequest {
-                    allow_return_traffic,
-                    source_filter: build_filter_spec("src", src_network, src_ip, src_port)?,
-                    destination_filter: build_filter_spec("dst", dst_network, dst_ip, dst_port)?,
-                    connection_states: states,
-                    ip_version,
-                    ..UpdateFirewallPolicyRequest::default()
-                }
-            };
-
-            controller
-                .execute(CoreCommand::UpdateFirewallPolicy {
-                    id: EntityId::from(id),
-                    update,
-                })
-                .await?;
-            if !global.quiet {
-                eprintln!("Firewall policy updated");
-            }
-            Ok(())
+            handle_update(
+                controller,
+                global,
+                id,
+                allow_return_traffic,
+                from_file,
+                src_network,
+                src_ip,
+                src_port,
+                dst_network,
+                dst_ip,
+                dst_port,
+                states,
+                ip_version,
+            )
+            .await
         }
 
         FirewallPoliciesCommand::Patch {
@@ -364,4 +336,179 @@ pub(super) async fn handle(
             Ok(())
         }
     }
+}
+
+#[allow(clippy::too_many_arguments, clippy::fn_params_excessive_bools)]
+async fn handle_create(
+    controller: &Controller,
+    global: &GlobalOpts,
+    from_file: Option<std::path::PathBuf>,
+    name: Option<String>,
+    action: Option<crate::cli::args::FirewallAction>,
+    source_zone: Option<String>,
+    dest_zone: Option<String>,
+    enabled: bool,
+    description: Option<String>,
+    logging: bool,
+    allow_return_traffic: bool,
+    src_network: Option<Vec<String>>,
+    src_ip: Option<Vec<String>>,
+    src_port: Option<Vec<String>>,
+    dst_network: Option<Vec<String>>,
+    dst_ip: Option<Vec<String>>,
+    dst_port: Option<Vec<String>>,
+    states: Option<Vec<String>>,
+    ip_version: Option<String>,
+    after_system: bool,
+) -> Result<(), CliError> {
+    let req = if let Some(path) = from_file.as_ref() {
+        let mut req: CreateFirewallPolicyRequest =
+            serde_json::from_value(util::read_json_file(path)?)?;
+        req.resolve_filters()
+            .map_err(|reason| CliError::Validation {
+                field: "filter".into(),
+                reason,
+            })?;
+        req
+    } else {
+        CreateFirewallPolicyRequest {
+            name: name.unwrap_or_default(),
+            action: action
+                .as_ref()
+                .map_or(unifly_api::model::FirewallAction::Block, map_fw_action),
+            source_zone_id: EntityId::from(source_zone.unwrap_or_default()),
+            destination_zone_id: EntityId::from(dest_zone.unwrap_or_default()),
+            enabled,
+            logging_enabled: logging,
+            allow_return_traffic,
+            description,
+            ip_version,
+            connection_states: states,
+            source_filter: build_filter_spec("src", src_network, src_ip, src_port)?,
+            destination_filter: build_filter_spec("dst", dst_network, dst_ip, dst_port)?,
+            src_network: None,
+            src_ip: None,
+            src_port: None,
+            dst_network: None,
+            dst_ip: None,
+            dst_port: None,
+        }
+    };
+
+    let source_zone_id = req.source_zone_id.clone();
+    let destination_zone_id = req.destination_zone_id.clone();
+
+    let result = controller
+        .execute(CoreCommand::CreateFirewallPolicy(req))
+        .await?;
+
+    if after_system {
+        move_policy_after_system(controller, result, source_zone_id, destination_zone_id).await?;
+    }
+
+    if !global.quiet {
+        if after_system {
+            eprintln!("Firewall policy created (after system-defined rules)");
+        } else {
+            eprintln!("Firewall policy created");
+        }
+    }
+    Ok(())
+}
+
+#[allow(clippy::too_many_arguments)]
+async fn handle_update(
+    controller: &Controller,
+    global: &GlobalOpts,
+    id: String,
+    allow_return_traffic: Option<bool>,
+    from_file: Option<std::path::PathBuf>,
+    src_network: Option<Vec<String>>,
+    src_ip: Option<Vec<String>>,
+    src_port: Option<Vec<String>>,
+    dst_network: Option<Vec<String>>,
+    dst_ip: Option<Vec<String>>,
+    dst_port: Option<Vec<String>>,
+    states: Option<Vec<String>>,
+    ip_version: Option<String>,
+) -> Result<(), CliError> {
+    if from_file.is_none()
+        && allow_return_traffic.is_none()
+        && src_network.is_none()
+        && src_ip.is_none()
+        && src_port.is_none()
+        && dst_network.is_none()
+        && dst_ip.is_none()
+        && dst_port.is_none()
+        && states.is_none()
+        && ip_version.is_none()
+    {
+        return Err(CliError::Validation {
+            field: "update".into(),
+            reason: "at least one update flag or --from-file is required".into(),
+        });
+    }
+
+    let update = if let Some(path) = from_file.as_ref() {
+        let mut update: UpdateFirewallPolicyRequest =
+            serde_json::from_value(util::read_json_file(path)?)?;
+        update
+            .resolve_filters()
+            .map_err(|reason| CliError::Validation {
+                field: "filter".into(),
+                reason,
+            })?;
+        update
+    } else {
+        UpdateFirewallPolicyRequest {
+            allow_return_traffic,
+            source_filter: build_filter_spec("src", src_network, src_ip, src_port)?,
+            destination_filter: build_filter_spec("dst", dst_network, dst_ip, dst_port)?,
+            connection_states: states,
+            ip_version,
+            ..UpdateFirewallPolicyRequest::default()
+        }
+    };
+
+    controller
+        .execute(CoreCommand::UpdateFirewallPolicy {
+            id: EntityId::from(id),
+            update,
+        })
+        .await?;
+    if !global.quiet {
+        eprintln!("Firewall policy updated");
+    }
+    Ok(())
+}
+
+/// Move a newly created firewall policy from "Before System Defined" to
+/// "After System Defined" in the zone-pair ordering.
+async fn move_policy_after_system(
+    controller: &Controller,
+    result: unifly_api::CommandResult,
+    source_zone_id: EntityId,
+    destination_zone_id: EntityId,
+) -> Result<(), CliError> {
+    if let unifly_api::CommandResult::CreatedId(created_id) = result {
+        let mut ordering = controller
+            .get_firewall_policy_ordering(&source_zone_id, &destination_zone_id)
+            .await?;
+        if let EntityId::Uuid(uuid) = &created_id {
+            ordering.before_system_defined.retain(|id| id != uuid);
+            ordering.after_system_defined.push(*uuid);
+        }
+        controller
+            .execute(CoreCommand::ReorderFirewallPolicies {
+                zone_pair: (source_zone_id, destination_zone_id),
+                ordered_ids: ordering
+                    .after_system_defined
+                    .into_iter()
+                    .map(EntityId::Uuid)
+                    .collect(),
+                after_system: true,
+            })
+            .await?;
+    }
+    Ok(())
 }

--- a/crates/unifly/src/cli/commands/firewall/policies.rs
+++ b/crates/unifly/src/cli/commands/firewall/policies.rs
@@ -308,6 +308,23 @@ pub(super) async fn handle(
                         .map(EntityId::Uuid)
                         .collect()
                 };
+
+                // Reject overlap: a policy can't be in both halves at once.
+                // Without this check the controller PUT would have the same
+                // UUID in both lists, which the controller may silently
+                // dedupe or reject ambiguously.
+                let preserved_set: std::collections::HashSet<&EntityId> =
+                    preserved.iter().collect();
+                if let Some(overlap) = new_ids.iter().find(|id| preserved_set.contains(id)) {
+                    let side = if after_system { "before-system" } else { "after-system" };
+                    return Err(CliError::Validation {
+                        field: "set".into(),
+                        reason: format!(
+                            "policy \"{overlap}\" is already in the {side} ordering for this zone-pair"
+                        ),
+                    });
+                }
+
                 let (before_system_ids, after_system_ids) = if after_system {
                     (preserved, new_ids)
                 } else {

--- a/crates/unifly/src/cli/commands/firewall/policies.rs
+++ b/crates/unifly/src/cli/commands/firewall/policies.rs
@@ -316,7 +316,11 @@ pub(super) async fn handle(
                 let preserved_set: std::collections::HashSet<&EntityId> =
                     preserved.iter().collect();
                 if let Some(overlap) = new_ids.iter().find(|id| preserved_set.contains(id)) {
-                    let side = if after_system { "before-system" } else { "after-system" };
+                    let side = if after_system {
+                        "before-system"
+                    } else {
+                        "after-system"
+                    };
                     return Err(CliError::Validation {
                         field: "set".into(),
                         reason: format!(

--- a/crates/unifly/src/cli/commands/firewall/policies.rs
+++ b/crates/unifly/src/cli/commands/firewall/policies.rs
@@ -449,15 +449,36 @@ async fn handle_create(
         .execute(CoreCommand::CreateFirewallPolicy(req))
         .await?;
 
-    if after_system {
-        move_policy_after_system(controller, result, source_zone_id, destination_zone_id).await?;
-    }
+    let created_id = match &result {
+        unifly_api::CommandResult::CreatedId(id) => Some(id.to_string()),
+        _ => None,
+    };
+
+    let reorder_err = if after_system {
+        move_policy_after_system(controller, result, source_zone_id, destination_zone_id)
+            .await
+            .err()
+    } else {
+        None
+    };
 
     if !global.quiet {
-        if after_system {
-            eprintln!("Firewall policy created (after system-defined rules)");
-        } else {
-            eprintln!("Firewall policy created");
+        match (after_system, &reorder_err, &created_id) {
+            (true, Some(err), Some(id)) => {
+                eprintln!(
+                    "Firewall policy created (id {id}); reorder after system-defined rules failed: {err}"
+                );
+                eprintln!(
+                    "Use `unifly firewall policies reorder --source-zone <ID> --dest-zone <ID> --set ... --after-system` to retry."
+                );
+            }
+            (true, Some(err), None) => {
+                eprintln!(
+                    "Firewall policy created; reorder after system-defined rules failed: {err}"
+                );
+            }
+            (true, None, _) => eprintln!("Firewall policy created (after system-defined rules)"),
+            (false, _, _) => eprintln!("Firewall policy created"),
         }
     }
     Ok(())

--- a/crates/unifly/src/cli/commands/firewall/policies.rs
+++ b/crates/unifly/src/cli/commands/firewall/policies.rs
@@ -282,12 +282,42 @@ pub(super) async fn handle(
                 parse_reorder_zone_pair(Some(source_zone.as_str()), Some(dest_zone.as_str()))?;
 
             if let Some(ids) = set {
-                let ordered_ids: Vec<EntityId> = ids.into_iter().map(EntityId::from).collect();
+                let new_ids = ids
+                    .into_iter()
+                    .map(|s| match EntityId::from(s.clone()) {
+                        id @ EntityId::Uuid(_) => Ok(id),
+                        EntityId::Legacy(_) => Err(CliError::Validation {
+                            field: "set".into(),
+                            reason: format!("\"{s}\" is not a valid policy UUID"),
+                        }),
+                    })
+                    .collect::<Result<Vec<EntityId>, _>>()?;
+                let ordering = controller
+                    .get_firewall_policy_ordering(&zone_pair.0, &zone_pair.1)
+                    .await?;
+                let preserved: Vec<EntityId> = if after_system {
+                    ordering
+                        .before_system_defined
+                        .into_iter()
+                        .map(EntityId::Uuid)
+                        .collect()
+                } else {
+                    ordering
+                        .after_system_defined
+                        .into_iter()
+                        .map(EntityId::Uuid)
+                        .collect()
+                };
+                let (before_system_ids, after_system_ids) = if after_system {
+                    (preserved, new_ids)
+                } else {
+                    (new_ids, preserved)
+                };
                 controller
                     .execute(CoreCommand::ReorderFirewallPolicies {
                         zone_pair,
-                        ordered_ids,
-                        after_system,
+                        before_system_ids,
+                        after_system_ids,
                     })
                     .await?;
                 if !global.quiet {
@@ -501,12 +531,16 @@ async fn move_policy_after_system(
         controller
             .execute(CoreCommand::ReorderFirewallPolicies {
                 zone_pair: (source_zone_id, destination_zone_id),
-                ordered_ids: ordering
+                before_system_ids: ordering
+                    .before_system_defined
+                    .into_iter()
+                    .map(EntityId::Uuid)
+                    .collect(),
+                after_system_ids: ordering
                     .after_system_defined
                     .into_iter()
                     .map(EntityId::Uuid)
                     .collect(),
-                after_system: true,
             })
             .await?;
     }

--- a/crates/unifly/src/cli/commands/firewall/policies.rs
+++ b/crates/unifly/src/cli/commands/firewall/policies.rs
@@ -309,24 +309,26 @@ pub(super) async fn handle(
                         .collect()
                 };
 
-                // Reject overlap: a policy can't be in both halves at once.
-                // Without this check the controller PUT would have the same
-                // UUID in both lists, which the controller may silently
-                // dedupe or reject ambiguously.
-                let preserved_set: std::collections::HashSet<&EntityId> =
-                    preserved.iter().collect();
-                if let Some(overlap) = new_ids.iter().find(|id| preserved_set.contains(id)) {
-                    let side = if after_system {
+                // A policy can only live in one half of the ordering at a
+                // time. If the user names an ID that's currently in the
+                // opposite half, treat it as a *move*: drop it from the
+                // preserved list so it ends up only in the target half.
+                // Reporting the move keeps the behavior visible.
+                let new_ids_set: std::collections::HashSet<&EntityId> = new_ids.iter().collect();
+                let preserved_len = preserved.len();
+                let preserved: Vec<EntityId> = preserved
+                    .into_iter()
+                    .filter(|id| !new_ids_set.contains(id))
+                    .collect();
+                let moved = preserved_len - preserved.len();
+                if moved > 0 && !global.quiet {
+                    let from_side = if after_system {
                         "before-system"
                     } else {
                         "after-system"
                     };
-                    return Err(CliError::Validation {
-                        field: "set".into(),
-                        reason: format!(
-                            "policy \"{overlap}\" is already in the {side} ordering for this zone-pair"
-                        ),
-                    });
+                    let plural = if moved == 1 { "y" } else { "ies" };
+                    eprintln!("Moved {moved} polic{plural} from {from_side} into the new ordering");
                 }
 
                 let (before_system_ids, after_system_ids) = if after_system {

--- a/crates/unifly/src/cli/commands/firewall/shared.rs
+++ b/crates/unifly/src/cli/commands/firewall/shared.rs
@@ -1,5 +1,5 @@
 use unifly_api::model::FirewallAction as ModelFirewallAction;
-use unifly_api::{EntityId, TrafficFilterSpec};
+use unifly_api::{EntityId, PortSpec, TrafficFilterSpec};
 
 use crate::cli::args::FirewallAction;
 use crate::cli::error::CliError;
@@ -18,39 +18,33 @@ pub(super) fn build_filter_spec(
     ips: Option<Vec<String>>,
     ports: Option<Vec<String>>,
 ) -> Result<Option<TrafficFilterSpec>, CliError> {
-    let selected = [
-        networks.as_ref().map(|_| "network"),
-        ips.as_ref().map(|_| "ip"),
-        ports.as_ref().map(|_| "port"),
-    ]
-    .into_iter()
-    .flatten()
-    .collect::<Vec<_>>();
-
-    if selected.len() > 1 {
+    // network + ip is invalid; port can combine with either
+    if networks.is_some() && ips.is_some() {
         return Err(CliError::Validation {
             field: format!("{field_prefix}-filter"),
-            reason: format!(
-                "choose only one of --{field_prefix}-network, --{field_prefix}-ip, or --{field_prefix}-port"
-            ),
+            reason: format!("cannot combine --{field_prefix}-network and --{field_prefix}-ip"),
         });
     }
+
+    let port_spec = ports.map(|items| PortSpec::Values {
+        items,
+        match_opposite: false,
+    });
 
     Ok(if let Some(network_ids) = networks {
         Some(TrafficFilterSpec::Network {
             network_ids,
             match_opposite: false,
+            ports: port_spec,
         })
     } else if let Some(addresses) = ips {
         Some(TrafficFilterSpec::IpAddress {
             addresses,
             match_opposite: false,
+            ports: port_spec,
         })
     } else {
-        ports.map(|ports| TrafficFilterSpec::Port {
-            ports,
-            match_opposite: false,
-        })
+        port_spec.map(|ports| TrafficFilterSpec::Port { ports })
     })
 }
 
@@ -73,7 +67,7 @@ pub(super) fn parse_reorder_zone_pair(
 mod tests {
     use super::{build_filter_spec, parse_reorder_zone_pair};
     use crate::cli::error::CliError;
-    use unifly_api::{EntityId, TrafficFilterSpec};
+    use unifly_api::{EntityId, PortSpec, TrafficFilterSpec};
 
     #[test]
     fn build_filter_spec_accepts_single_filter_family() {
@@ -94,6 +88,30 @@ mod tests {
             Err(CliError::Validation { field, .. }) => assert_eq!(field, "src-filter"),
             Ok(_) => panic!("expected validation error, got success"),
             Err(other) => panic!("expected validation error, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn build_filter_spec_combines_ip_and_port() {
+        let spec = build_filter_spec(
+            "dst",
+            None,
+            Some(vec!["10.0.40.10".into()]),
+            Some(vec!["80".into()]),
+        )
+        .expect("ip + port should succeed");
+
+        match spec {
+            Some(TrafficFilterSpec::IpAddress {
+                addresses, ports, ..
+            }) => {
+                assert_eq!(addresses, vec!["10.0.40.10"]);
+                let Some(PortSpec::Values { items, .. }) = ports else {
+                    panic!("expected PortSpec::Values, got {ports:?}")
+                };
+                assert_eq!(items, vec!["80"]);
+            }
+            other => panic!("expected IpAddress with ports, got {other:?}"),
         }
     }
 

--- a/skills/unifly/references/commands.md
+++ b/skills/unifly/references/commands.md
@@ -196,7 +196,7 @@ unifly firewall policies create --name NAME --action allow|block|reject \
   [--src-ip IP,CIDR,RANGE] [--dst-ip ...] [--src-port N,N] [--dst-port ...] \
   [--src-network ID] [--dst-network ID] \
   [--states NEW,ESTABLISHED] [--ip-version IPV4_ONLY|IPV6_ONLY|BOTH] \
-  [--description TEXT] [--logging] [-F payload.json]
+  [--description TEXT] [--logging] [--after-system] [-F payload.json]
 unifly firewall policies update <id> [flags...]
 unifly firewall policies patch <id> [--enabled true|false] [--logging true|false]
 unifly firewall policies delete <id>
@@ -212,10 +212,16 @@ unifly firewall policies reorder --source-zone ZID --dest-zone ZID (--get | --se
   (`10.0.0.1-10.0.0.100`), comma-separated.
 - `reorder --get` prints the current order. `reorder --set` writes a new
   order. Round-trip pattern: get, edit, set.
+- `--after-system` on `create` places the new policy after system-defined
+  rules in one step (creates then reorders).
 - `reorder --after-system` places user policies after system-defined rules.
 - `--logging` is a boolean; both bare form (`--logging`) and explicit
   (`--logging true`) work.
 - `--description` exists on `create` and `update`.
+- `--from-file` supports shorthand fields: `dst_ip`, `dst_port`, `src_ip`,
+  `src_port`, `dst_network`, `src_network` (and `src_*` variants). These
+  are resolved into `source_filter` / `destination_filter` before
+  submission.
 
 ### Zones
 


### PR DESCRIPTION
## Summary

- `firewall policies create/update --from-file` correctly handles JSON payloads with combined IP+port destination filters. The wire payload nests `portFilter` inside `ipAddressFilter` per the controller's schema; the `dst_ip`/`dst_port` shorthand fields are no longer silently dropped, and the outer traffic-filter type is sent as `IP_ADDRESS` (was `IP_ADDRESSES`).
- Block actions send `BLOCK` on the wire. The Integration API rejects `DROP` with `Invalid $.action.type value 'DROP' (valid values: 'ALLOW', 'BLOCK', 'REJECT')`, so the previous mapping made `firewall policies create --action block` non-functional. On update, a stored `DROP` action is normalized to `BLOCK` and any other unrecognized type is passed through verbatim, so update paths can't silently flip a block rule into an allow rule.
- `--after-system` flag on `firewall policies create` places new policies after system-defined rules (~40000 instead of ~10000) in one step.
- `firewall policies reorder` preserves both halves of the zone-pair ordering on every PUT. Editing one half no longer wipes the other (e.g., adding an after-system policy on a zone-pair with existing before-system rules).
- A canonical `PortSpec` tagged enum (`Values` | `MatchingList`) backs the port-side wire format and is exported from `unifly_api`. JSON files written against the prior shape (flat `Vec<String>` for `Port.ports`, `match_opposite` at the variant level, `port_matching_list` top-level variant) still deserialize via a `TrafficFilterSpecWire` shim — no migration required.
- Smaller fixes: `PORT_NUMBER_RANGE` instead of `PORT_RANGE` in port-filter payloads; `"logging"` accepted as a deserialize alias for `logging_enabled` in JSON files; `firewall policies reorder --set "..."` errors on non-UUID inputs before any PUT instead of silently dropping them.

## Test plan

- [x] `cargo fmt --all -- --check` clean
- [x] `cargo clippy --workspace --all-targets` clean (no warnings)
- [x] `cargo test --workspace` clean (all unit + integration tests pass)
- [x] `cargo run -- firewall policies create --help` shows `-F/--from-file` and `--after-system`
- [x] New unit tests cover: legacy `Port` flat-array deserialize, `PortSpec` JSON round-trip, wire-payload nesting for both inline values and `TRAFFIC_MATCHING_LIST` references
- [x] **Live controller**: `firewall policies create -F` with `IpAddress + ports` JSON → policy lands on the controller with `kind: ip_address`, `addresses: [...]`, and `ports: {kind: values, items: [...]}` correctly nested. Verified via `firewall policies list -o json`.
- [x] **Live controller**: `firewall policies create --action block` succeeds.
- [x] **Live controller**: `firewall policies create --after-system` on a zone-pair with existing before-system rules — `beforeSystemDefined` list is preserved.
- [x] **Live controller**: `firewall policies reorder --set "<not-a-uuid>"` errors with `"<input>" is not a valid policy UUID`, no PUT issued.

Note: `just fmt-check` also runs prettier on the whole repo and flags `.cursor-plugin/plugin.json`, but that's pre-existing on `main` and unrelated to this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * `firewall policies create` gains `--after-system` to place a new policy after system rules in one step.
  * `--from-file` accepts shorthand src/dst fields (ip/port/network) which are converted into proper filters.
  * Ports may now be specified alongside IP/network filters (ip+port nesting).

* **Bug Fixes**
  * Port range serialization fixed for API compatibility.
  * Block action mapping corrected to avoid misclassified rules.

* **Documentation**
  * CLI docs updated for the new firewall policy options.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->