### PR TITLE
fix(sites): match by display name and slug, not just slug

### DIFF
--- a/crates/unifly-api/src/controller/lifecycle.rs
+++ b/crates/unifly-api/src/controller/lifecycle.rs
@@ -13,7 +13,7 @@ use crate::core_error::CoreError;
 use crate::websocket::{ReconnectConfig, WebSocketHandle};
 use crate::{IntegrationClient, SessionClient};
 
-use super::support::{build_transport, resolve_site_id, tls_to_transport};
+use super::support::{build_transport, resolve_site, tls_to_transport};
 use super::{COMMAND_CHANNEL_SIZE, ConnectionState, Controller, refresh};
 
 impl Controller {
@@ -69,7 +69,7 @@ impl Controller {
                 // A 404 here usually means the controller doesn't expose
                 // the Integration API (older or self-hosted UNA without
                 // Settings > Integrations). Surface a targeted hint.
-                let site_id = resolve_site_id(&integration, &config.site)
+                let resolved = resolve_site(&integration, &config.site)
                     .await
                     .map_err(|e| match &e {
                         CoreError::Api {
@@ -87,10 +87,10 @@ impl Controller {
                         }
                         _ => e,
                     })?;
-                debug!(site_id = %site_id, "resolved Integration API site UUID");
+                debug!(site_id = %resolved.id, slug = %resolved.slug, "resolved Integration API site");
 
                 *self.inner.integration_client.lock().await = Some(Arc::new(integration));
-                *self.inner.site_id.lock().await = Some(site_id);
+                *self.inner.site_id.lock().await = Some(resolved.id);
 
                 // Also create a session client using the same API key.
                 // UniFi OS accepts X-API-KEY on session endpoints, which
@@ -110,7 +110,7 @@ impl Controller {
                 let session = SessionClient::with_client(
                     legacy_http,
                     config.url.clone(),
-                    config.site.clone(),
+                    resolved.slug,
                     platform,
                     crate::session::client::SessionAuth::ApiKey,
                 );
@@ -159,7 +159,7 @@ impl Controller {
                     platform,
                 )?;
 
-                let site_id = resolve_site_id(&integration, &config.site)
+                let resolved = resolve_site(&integration, &config.site)
                     .await
                     .map_err(|e| match &e {
                         CoreError::Api {
@@ -177,20 +177,15 @@ impl Controller {
                         }
                         _ => e,
                     })?;
-                debug!(site_id = %site_id, "resolved Integration API site UUID");
+                debug!(site_id = %resolved.id, slug = %resolved.slug, "resolved Integration API site");
 
                 *self.inner.integration_client.lock().await = Some(Arc::new(integration));
-                *self.inner.site_id.lock().await = Some(site_id);
+                *self.inner.site_id.lock().await = Some(resolved.id);
 
                 // Session API client — attempt login but degrade gracefully
                 // if it fails. The Integration API is the primary surface;
                 // Session adds events, stats, and admin ops.
-                match SessionClient::new(
-                    config.url.clone(),
-                    config.site.clone(),
-                    platform,
-                    &transport,
-                ) {
+                match SessionClient::new(config.url.clone(), resolved.slug, platform, &transport) {
                     Ok(client) => {
                         let cache = build_session_cache(config);
                         let login_result = if let Some(ref cache) = cache {
@@ -242,15 +237,11 @@ impl Controller {
                     crate::ControllerPlatform::Cloud,
                 )?;
 
-                let site_id = if let Ok(uuid) = uuid::Uuid::parse_str(&config.site) {
-                    uuid
-                } else {
-                    resolve_site_id(&integration, &config.site).await?
-                };
-                debug!(site_id = %site_id, "resolved cloud Integration API site UUID");
+                let resolved = resolve_site(&integration, &config.site).await?;
+                debug!(site_id = %resolved.id, slug = %resolved.slug, "resolved cloud Integration API site");
 
                 *self.inner.integration_client.lock().await = Some(Arc::new(integration));
-                *self.inner.site_id.lock().await = Some(site_id);
+                *self.inner.site_id.lock().await = Some(resolved.id);
 
                 let msg =
                     "Cloud connector mode active: events watch, Wi-Fi observability, admin/session features, and live WebSocket data are unavailable"
@@ -309,7 +300,10 @@ impl Controller {
             return;
         };
 
-        let ws_path = ws_path_template.replace("{site}", &self.inner.config.site);
+        // Use the resolved slug stored on the session client, not the
+        // raw `config.site` -- which may be a display name or UUID that
+        // the WebSocket route does not understand.
+        let ws_path = ws_path_template.replace("{site}", session.site());
         let base_url = &self.inner.config.url;
         let scheme = if base_url.scheme() == "https" {
             "wss"

--- a/crates/unifly-api/src/controller/support.rs
+++ b/crates/unifly-api/src/controller/support.rs
@@ -113,30 +113,111 @@ pub(super) fn tls_to_transport(tls: &TlsVerification) -> TlsMode {
     }
 }
 
-/// Resolve the Integration API site UUID from a site name or UUID string.
+/// A site resolved against the Integration API: the canonical UUID plus
+/// the slug that the Session API expects in URL paths (`/api/s/<slug>/...`).
+#[derive(Debug)]
+pub(super) struct ResolvedSite {
+    pub id: uuid::Uuid,
+    pub slug: String,
+}
+
+/// Resolve a site identifier to its Integration UUID and Session slug.
 ///
-/// If `site_name` is already a valid UUID, returns it directly.
-/// Otherwise lists all sites and finds the one matching by `internal_reference`.
-pub(super) async fn resolve_site_id(
+/// Matches in priority order:
+/// 1. UUID fast-path (input parses as `Uuid` and matches a known site).
+/// 2. Exact `internal_reference` match (the slug, e.g. `default`).
+/// 3. Exact `name` match (the display label, e.g. `Default` or `Home Network`).
+/// 4. Case-insensitive match on either field.
+///
+/// Falling through to display-name matching avoids the trap where
+/// `unifly sites list` shows the human-readable `name` column and the user
+/// pastes that into config without realizing the slug is the canonical
+/// identifier (issue #16). Both the UUID and the resolved slug are returned
+/// so Session-backed callers can rebuild URLs against the correct slug
+/// instead of the user's raw input.
+pub(super) async fn resolve_site(
     client: &IntegrationClient,
     site_name: &str,
-) -> Result<uuid::Uuid, CoreError> {
-    // Fast path: if the input is already a UUID, use it directly.
-    if let Ok(uuid) = uuid::Uuid::parse_str(site_name) {
-        return Ok(uuid);
-    }
-
+) -> Result<ResolvedSite, CoreError> {
     let sites = client
         .paginate_all(50, |off, lim| client.list_sites(off, lim))
         .await?;
+    resolve_site_in(&sites, site_name)
+}
 
-    sites
-        .into_iter()
-        .find(|site| site.internal_reference == site_name)
-        .map(|site| site.id)
-        .ok_or_else(|| CoreError::SiteNotFound {
-            name: site_name.to_owned(),
+/// Pure matching logic, factored out for direct unit testing without the
+/// network round-trip in [`resolve_site`].
+fn resolve_site_in(
+    sites: &[crate::integration_types::SiteResponse],
+    site_name: &str,
+) -> Result<ResolvedSite, CoreError> {
+    if let Ok(uuid) = uuid::Uuid::parse_str(site_name)
+        && let Some(site) = sites.iter().find(|s| s.id == uuid)
+    {
+        return Ok(ResolvedSite {
+            id: site.id,
+            slug: site.internal_reference.clone(),
+        });
+    }
+
+    // Slug is the canonical identifier; an exact slug match is unambiguous
+    // by definition (UniFi enforces uniqueness server-side).
+    if let Some(site) = sites.iter().find(|s| s.internal_reference == site_name) {
+        return Ok(ResolvedSite {
+            id: site.id,
+            slug: site.internal_reference.clone(),
+        });
+    }
+
+    // Fuzzy matches: collect every site that matches by display name or by
+    // case-insensitive variants. Reject the operation if more than one
+    // distinct site comes back -- silently picking the first hit can route
+    // reads/writes to the wrong site.
+    let fuzzy: Vec<&_> = sites
+        .iter()
+        .filter(|s| {
+            s.name == site_name
+                || s.internal_reference.eq_ignore_ascii_case(site_name)
+                || s.name.eq_ignore_ascii_case(site_name)
         })
+        .collect();
+
+    let unique: std::collections::HashSet<uuid::Uuid> = fuzzy.iter().map(|s| s.id).collect();
+
+    if unique.len() == 1 {
+        let site = fuzzy[0];
+        return Ok(ResolvedSite {
+            id: site.id,
+            slug: site.internal_reference.clone(),
+        });
+    }
+
+    if unique.len() > 1 {
+        let matches = fuzzy
+            .into_iter()
+            .map(|s| crate::core_error::SiteHint {
+                internal_reference: s.internal_reference.clone(),
+                display_name: s.name.clone(),
+            })
+            .collect();
+        return Err(CoreError::SiteAmbiguous {
+            name: site_name.to_owned(),
+            matches,
+        });
+    }
+
+    let available = sites
+        .iter()
+        .map(|s| crate::core_error::SiteHint {
+            internal_reference: s.internal_reference.clone(),
+            display_name: s.name.clone(),
+        })
+        .collect();
+
+    Err(CoreError::SiteNotFound {
+        name: site_name.to_owned(),
+        available,
+    })
 }
 
 /// Extract a `Uuid` from an `EntityId`, or return an error.
@@ -223,4 +304,104 @@ pub(super) fn client_mac(store: &DataStore, id: &EntityId) -> Result<MacAddress,
         .ok_or_else(|| CoreError::ClientNotFound {
             identifier: id.to_string(),
         })
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used)]
+mod tests {
+    use super::resolve_site_in;
+    use crate::core_error::CoreError;
+    use crate::integration_types::SiteResponse;
+    use uuid::Uuid;
+
+    fn site(id: &str, internal: &str, name: &str) -> SiteResponse {
+        SiteResponse {
+            id: Uuid::parse_str(id).expect("valid uuid"),
+            internal_reference: internal.into(),
+            name: name.into(),
+        }
+    }
+
+    fn default_site() -> SiteResponse {
+        site(
+            "11111111-1111-1111-1111-111111111111",
+            "default",
+            "Main Site",
+        )
+    }
+
+    fn guest_site() -> SiteResponse {
+        site(
+            "22222222-2222-2222-2222-222222222222",
+            "guest",
+            "Guest Network",
+        )
+    }
+
+    #[test]
+    fn matches_known_uuid_returns_canonical_slug() {
+        let sites = vec![default_site(), guest_site()];
+        let resolved = resolve_site_in(&sites, "11111111-1111-1111-1111-111111111111").unwrap();
+        assert_eq!(resolved.slug, "default");
+    }
+
+    #[test]
+    fn unmatched_uuid_falls_through_to_not_found() {
+        let sites = vec![default_site()];
+        let err = resolve_site_in(&sites, "33333333-3333-3333-3333-333333333333").unwrap_err();
+        assert!(matches!(err, CoreError::SiteNotFound { .. }));
+    }
+
+    #[test]
+    fn exact_slug_match_wins_over_case_insensitive_name_collision() {
+        // Site A has slug "default" + name "Default Site". Site B has slug
+        // "default-backup" + name "default" (a contrived but legal label).
+        // Input "default" must match Site A by exact slug, not Site B by name.
+        let target = site(
+            "44444444-4444-4444-4444-444444444444",
+            "default",
+            "Default Site",
+        );
+        let collision = site(
+            "55555555-5555-5555-5555-555555555555",
+            "default-backup",
+            "default",
+        );
+        let sites = vec![target, collision];
+        let resolved = resolve_site_in(&sites, "default").unwrap();
+        assert_eq!(
+            resolved.id.to_string(),
+            "44444444-4444-4444-4444-444444444444"
+        );
+        assert_eq!(resolved.slug, "default");
+    }
+
+    #[test]
+    fn duplicate_display_names_return_ambiguous() {
+        let a = site("66666666-6666-6666-6666-666666666666", "home1", "Home");
+        let b = site("77777777-7777-7777-7777-777777777777", "home2", "Home");
+        let sites = vec![a, b];
+        let err = resolve_site_in(&sites, "Home").unwrap_err();
+        match err {
+            CoreError::SiteAmbiguous { matches, .. } => assert_eq!(matches.len(), 2),
+            other => panic!("expected SiteAmbiguous, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn case_insensitive_name_match_against_single_site_succeeds() {
+        let sites = vec![default_site(), guest_site()];
+        let resolved = resolve_site_in(&sites, "GUEST NETWORK").unwrap();
+        assert_eq!(resolved.slug, "guest");
+    }
+
+    #[test]
+    fn no_match_returns_not_found_with_full_candidate_list() {
+        let sites = vec![default_site(), guest_site()];
+        let err = resolve_site_in(&sites, "iot").unwrap_err();
+        match err {
+            CoreError::SiteNotFound { available, .. } => assert_eq!(available.len(), 2),
+            other => panic!("expected SiteNotFound, got {other:?}"),
+        }
+    }
 }

--- a/crates/unifly-api/src/core_error.rs
+++ b/crates/unifly-api/src/core_error.rs
@@ -5,7 +5,46 @@
 // The `From<crate::error::Error>` impl translates transport-layer errors
 // into domain-appropriate variants.
 
+use std::fmt::Write as _;
+
 use thiserror::Error;
+
+/// Lightweight site descriptor returned with `SiteNotFound` to help the
+/// caller see what slugs/labels the controller actually exposes.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SiteHint {
+    pub internal_reference: String,
+    pub display_name: String,
+}
+
+fn format_site_not_found(name: &str, available: &[SiteHint]) -> String {
+    let mut out = format!("Site not found: {name}");
+    if !available.is_empty() {
+        out.push_str(". Available sites:");
+        for hint in available {
+            // safe: writing into a String never errors
+            let _ = write!(
+                &mut out,
+                " {} ({})",
+                hint.internal_reference, hint.display_name
+            );
+        }
+    }
+    out
+}
+
+fn format_site_ambiguous(name: &str, matches: &[SiteHint]) -> String {
+    let mut out = format!("Site '{name}' is ambiguous; multiple sites match:");
+    for hint in matches {
+        let _ = write!(
+            &mut out,
+            " {} ({})",
+            hint.internal_reference, hint.display_name
+        );
+    }
+    out.push_str(". Use the slug or UUID instead");
+    out
+}
 
 /// Unified error type for the core crate.
 #[derive(Debug, Error)]
@@ -33,8 +72,21 @@ pub enum CoreError {
     #[error("Network not found: {identifier}")]
     NetworkNotFound { identifier: String },
 
-    #[error("Site not found: {name}")]
-    SiteNotFound { name: String },
+    #[error("{}", format_site_not_found(.name, .available))]
+    SiteNotFound {
+        name: String,
+        /// Available sites discovered on the controller, used to render a
+        /// helpful "did you mean..." list in the error message.
+        available: Vec<SiteHint>,
+    },
+
+    #[error("{}", format_site_ambiguous(.name, .matches))]
+    SiteAmbiguous {
+        name: String,
+        /// Sites whose `name` (or case-insensitive variants) all matched.
+        /// At least two entries; the user must disambiguate by slug or UUID.
+        matches: Vec<SiteHint>,
+    },
 
     #[error("Entity not found: {entity_type} with id {identifier}")]
     NotFound {
@@ -173,5 +225,62 @@ impl From<crate::error::Error> for CoreError {
                 required: "a newer controller firmware".into(),
             },
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{CoreError, SiteHint};
+
+    #[test]
+    fn site_not_found_renders_with_no_candidates() {
+        let err = CoreError::SiteNotFound {
+            name: "ghost".into(),
+            available: Vec::new(),
+        };
+        assert_eq!(err.to_string(), "Site not found: ghost");
+    }
+
+    #[test]
+    fn site_ambiguous_lists_matches_and_recommends_slug() {
+        let err = CoreError::SiteAmbiguous {
+            name: "Home".into(),
+            matches: vec![
+                SiteHint {
+                    internal_reference: "home1".into(),
+                    display_name: "Home".into(),
+                },
+                SiteHint {
+                    internal_reference: "home2".into(),
+                    display_name: "Home".into(),
+                },
+            ],
+        };
+        let rendered = err.to_string();
+        assert!(rendered.contains("ambiguous"));
+        assert!(rendered.contains("home1 (Home)"));
+        assert!(rendered.contains("home2 (Home)"));
+        assert!(rendered.contains("slug or UUID"));
+    }
+
+    #[test]
+    fn site_not_found_lists_available_sites() {
+        let err = CoreError::SiteNotFound {
+            name: "Default".into(),
+            available: vec![
+                SiteHint {
+                    internal_reference: "default".into(),
+                    display_name: "Main Site".into(),
+                },
+                SiteHint {
+                    internal_reference: "guest".into(),
+                    display_name: "Guest Network".into(),
+                },
+            ],
+        };
+        let rendered = err.to_string();
+        assert!(rendered.contains("Site not found: Default"));
+        assert!(rendered.contains("default (Main Site)"));
+        assert!(rendered.contains("guest (Guest Network)"));
     }
 }

--- a/crates/unifly-api/src/lib.rs
+++ b/crates/unifly-api/src/lib.rs
@@ -67,7 +67,7 @@ pub use command::requests::*;
 pub use command::{Command, CommandResult};
 pub use config::{AuthCredentials, ControllerConfig, TlsVerification};
 pub use controller::{ApplyPortsSummary, ConnectionState, Controller, PortProfileUpdate};
-pub use core_error::CoreError;
+pub use core_error::{CoreError, SiteHint};
 pub use store::DataStore;
 pub use stream::EntityStream;
 

--- a/crates/unifly/src/cli/commands/sites.rs
+++ b/crates/unifly/src/cli/commands/sites.rs
@@ -17,6 +17,8 @@ use super::util;
 struct SiteRow {
     #[tabled(rename = "ID")]
     id: String,
+    #[tabled(rename = "Internal")]
+    internal: String,
     #[tabled(rename = "Name")]
     name: String,
     #[tabled(rename = "Devices")]
@@ -28,6 +30,7 @@ struct SiteRow {
 fn site_row(s: &Arc<Site>, p: &output::Painter) -> SiteRow {
     SiteRow {
         id: p.id(&s.id.to_string()),
+        internal: p.id(&s.internal_name),
         name: p.name(&s.name),
         devices: p.number(&s.device_count.map(|c| c.to_string()).unwrap_or_default()),
         clients: p.number(&s.client_count.map(|c| c.to_string()).unwrap_or_default()),

--- a/crates/unifly/src/cli/error.rs
+++ b/crates/unifly/src/cli/error.rs
@@ -96,6 +96,27 @@ pub enum CliError {
         identifier: String,
     },
 
+    #[error("Site '{name}' not found on this controller")]
+    #[diagnostic(
+        code(unifi::site_not_found),
+        help(
+            "Available sites: {available}\n\
+             Set `site = \"<slug>\"` in your profile to one of the slugs above (the part before the parens),\n\
+             or pass --site <slug>. The display name and slug are not always the same."
+        )
+    )]
+    SiteNotFound { name: String, available: String },
+
+    #[error("Site '{name}' is ambiguous on this controller")]
+    #[diagnostic(
+        code(unifi::site_ambiguous),
+        help(
+            "Multiple sites match: {matches}\n\
+             Use the slug or UUID (the part before the parens) to disambiguate."
+        )
+    )]
+    SiteAmbiguous { name: String, matches: String },
+
     // ── API ──────────────────────────────────────────────────────────
     #[error("API error{}: {message}", if code.is_empty() { String::new() } else { format!(" ({code})") })]
     #[diagnostic(code(unifi::api_error))]
@@ -196,10 +217,12 @@ impl CliError {
         match self {
             Self::ConnectionFailed { .. } | Self::TlsError { .. } => exit_code::CONNECTION,
             Self::AuthFailed { .. } | Self::NoCredentials { .. } => exit_code::AUTH,
-            Self::NotFound { .. } => exit_code::NOT_FOUND,
+            Self::NotFound { .. } | Self::SiteNotFound { .. } => exit_code::NOT_FOUND,
             Self::Conflict { .. } => exit_code::CONFLICT,
             Self::Timeout { .. } => exit_code::TIMEOUT,
-            Self::Validation { .. } | Self::NonInteractiveRequiresYes { .. } => exit_code::USAGE,
+            Self::Validation { .. }
+            | Self::NonInteractiveRequiresYes { .. }
+            | Self::SiteAmbiguous { .. } => exit_code::USAGE,
             Self::Unsupported { .. } | Self::NotYetImplemented { .. } => exit_code::PERMISSION,
             _ => exit_code::GENERAL,
         }
@@ -242,10 +265,14 @@ impl From<CoreError> for CliError {
                 list_command: "clients list".into(),
             },
 
-            CoreError::SiteNotFound { name } => CliError::NotFound {
-                resource_type: "site".into(),
-                identifier: name,
-                list_command: "sites list".into(),
+            CoreError::SiteNotFound { name, available } => CliError::SiteNotFound {
+                name,
+                available: render_site_hints(&available),
+            },
+
+            CoreError::SiteAmbiguous { name, matches } => CliError::SiteAmbiguous {
+                name,
+                matches: render_site_hints(&matches),
             },
 
             CoreError::NetworkNotFound { identifier } => CliError::NotFound {
@@ -318,4 +345,15 @@ impl From<CoreError> for CliError {
             },
         }
     }
+}
+
+fn render_site_hints(hints: &[unifly_api::SiteHint]) -> String {
+    if hints.is_empty() {
+        return "(none discovered -- run `unifly sites list` to verify connectivity)".into();
+    }
+    hints
+        .iter()
+        .map(|h| format!("{} ({})", h.internal_reference, h.display_name))
+        .collect::<Vec<_>>()
+        .join(", ")
 }


### PR DESCRIPTION
## Summary

- `resolve_site_id` now matches by id, slug (`internal_reference`), and display `name`, with case-insensitive fallback. Renamed to `resolve_site` and returns a `ResolvedSite { id, slug }` so Session-backed callers can build URLs against the resolved slug instead of the user's raw input.
- `SessionClient` and the WebSocket URL builder now use `resolved.slug` (via `session.site()`) for `/api/s/<slug>/...` and `/wss/s/<slug>/...` paths.
- Ambiguous display-name matches (e.g. two sites named `Home`) return a new `SiteAmbiguous` error and ask the user to disambiguate by slug or UUID, instead of silently picking the first match.
- `SiteNotFound` now lists every discovered site as `slug (Display Name)` so the user can self-correct without a second round-trip.
- `unifly sites list` exposes an `Internal` column alongside `Name` so the slug is visible.
- New `CliError::SiteNotFound` and `CliError::SiteAmbiguous` variants exit with `NOT_FOUND` and `USAGE` codes respectively.

## The Bug

User on issue #16 reported that `unifly` returned "unable to locate site" against UniFi OS Server 5.0.6, while curl with the same URL and key worked fine. The trace showed the Integration `/v1/sites` response being read correctly, but `resolve_site_id` only matched against `internal_reference` (the slug), and `unifly sites list` only displayed `id` and `name` (no slug). Users naturally copy what they see in the table into `site = "..."` and hit a hard error with no way to know the slug is the canonical identifier.

The reporter is on UniFi OS Server, but the bug is platform-independent — it hits anyone whose site display name differs from the slug, on any UniFi OS variant.

## Codex review iterations

This PR was hardened across four cross-model review passes. Codex caught three follow-on issues that the initial fix missed:

1. The first version returned only the UUID and discarded the resolved slug, so Session API calls still hit `/api/s/<display-name>/...` on the new path. Now returns `ResolvedSite { id, slug }`.
2. The `CliError::SiteNotFound` variant wasn't in the `NOT_FOUND` exit-code arm, regressing scripts that rely on exit code 4. Added.
3. `spawn_websocket` still built the WS URL from `config.site` (raw input). Now reads the resolved slug from `session.site()`.
4. Display-name fuzzy matches silently picked the first hit when multiple sites shared a name. Now collects all matches and rejects ambiguous input via `SiteAmbiguous`.

## Test plan

- [x] `cargo test --workspace` passes (151 unit tests, +1 ambiguity regression, +1 not-found regression)
- [x] `cargo clippy --workspace --all-targets` clean
- [x] `cargo fmt --all -- --check` clean
- [ ] Original issue reporter can verify by re-running their failing command after upgrading

Fixes #16.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced site resolution with detailed error messages showing available sites when lookups fail or result in ambiguous matches
  * Added "Internal" column to the CLI sites listing for improved site identification

* **Bug Fixes**
  * Fixed WebSocket URL generation to resolve the correct site reference

<!-- end of auto-generated comment: release notes by coderabbit.ai -->