### PR TITLE
fix(firewall): parse legacy policies returned without UUID

### DIFF
--- a/.cursor-plugin/plugin.json
+++ b/.cursor-plugin/plugin.json
@@ -21,11 +21,6 @@
     "wifi"
   ],
   "category": "developer-tools",
-  "tags": [
-    "networking",
-    "cli",
-    "tui",
-    "infrastructure"
-  ],
+  "tags": ["networking", "cli", "tui", "infrastructure"],
   "skills": "./skills/"
 }

--- a/crates/unifly-api/src/controller/commands/policy/firewall.rs
+++ b/crates/unifly-api/src/controller/commands/policy/firewall.rs
@@ -44,9 +44,10 @@ pub(super) async fn route(ctx: &CommandContext, cmd: Command) -> Result<CommandR
                 connection_state_filter: req.connection_states,
             };
             let resp = ic.create_firewall_policy(&sid, &body).await?;
-            Ok(CommandResult::CreatedId(crate::model::EntityId::Uuid(
-                resp.id,
-            )))
+            let id = resp.id.ok_or_else(|| CoreError::ValidationFailed {
+                message: "firewall policy create response did not include an id".into(),
+            })?;
+            Ok(CommandResult::CreatedId(crate::model::EntityId::Uuid(id)))
         }
         Command::UpdateFirewallPolicy { id, update } => {
             let (ic, sid) = require_integration(integration, site_id, "UpdateFirewallPolicy")?;

--- a/crates/unifly-api/src/convert/firewall.rs
+++ b/crates/unifly-api/src/convert/firewall.rs
@@ -69,8 +69,13 @@ impl From<integration_types::FirewallPolicyResponse> for FirewallPolicy {
             })
             .unwrap_or_default();
 
+        let id = p.id.map_or_else(
+            || synthesize_legacy_policy_id(&source_endpoint, &destination_endpoint, index, &p.name),
+            EntityId::Uuid,
+        );
+
         FirewallPolicy {
-            id: EntityId::Uuid(p.id),
+            id,
             name: p.name,
             description: p.description,
             enabled: p.enabled,
@@ -90,6 +95,24 @@ impl From<integration_types::FirewallPolicyResponse> for FirewallPolicy {
             data_source: DataSource::IntegrationApi,
         }
     }
+}
+
+fn synthesize_legacy_policy_id(
+    source: &PolicyEndpoint,
+    destination: &PolicyEndpoint,
+    index: Option<i32>,
+    name: &str,
+) -> EntityId {
+    let src = source
+        .zone_id
+        .as_ref()
+        .map_or_else(|| "none".to_owned(), ToString::to_string);
+    let dst = destination
+        .zone_id
+        .as_ref()
+        .map_or_else(|| "none".to_owned(), ToString::to_string);
+    let idx = index.map_or_else(|| "noindex".to_owned(), |i| i.to_string());
+    EntityId::Legacy(format!("fwp:legacy:{src}:{dst}:{idx}:{name}"))
 }
 
 fn convert_policy_endpoint(
@@ -418,6 +441,32 @@ pub fn firewall_group_from_session(v: &serde_json::Value) -> Option<FirewallGrou
 mod tests {
     use super::*;
     use serde_json::json;
+
+    #[test]
+    fn firewall_policy_without_id_synthesizes_legacy_id() {
+        let raw = json!({
+            "name": "DropInvalid",
+            "enabled": true,
+            "action": {"type": "DROP"},
+            "ipProtocolScope": {"ipVersion": "IPV4_AND_IPV6"},
+            "loggingEnabled": true,
+            "source": {"zoneId": "fedb7e64-ff34-4dcb-ae6d-9645807b3329"},
+            "destination": {"zoneId": "6cfd721d-0c5d-4dde-a2ee-cfdc386ebd9c"},
+            "index": 10001
+        });
+
+        let response: integration_types::FirewallPolicyResponse =
+            serde_json::from_value(raw).expect("legacy policy without id should parse");
+        assert!(response.id.is_none());
+
+        let policy = FirewallPolicy::from(response);
+        assert_eq!(
+            policy.id.to_string(),
+            "fwp:legacy:fedb7e64-ff34-4dcb-ae6d-9645807b3329:6cfd721d-0c5d-4dde-a2ee-cfdc386ebd9c:10001:DropInvalid"
+        );
+        assert_eq!(policy.name, "DropInvalid");
+        assert!(policy.logging_enabled);
+    }
 
     #[test]
     fn firewall_group_from_session_parses_port_group() {

--- a/crates/unifly-api/src/integration/types/policy.rs
+++ b/crates/unifly-api/src/integration/types/policy.rs
@@ -312,7 +312,10 @@ pub enum DomainFilter {
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct FirewallPolicyResponse {
-    pub id: Uuid,
+    /// Integration UUID. Legacy user policies migrated from pre-zone firewall
+    /// config can arrive without one.
+    #[serde(default)]
+    pub id: Option<Uuid>,
     pub name: String,
     #[serde(default)]
     pub description: Option<String>,

--- a/crates/unifly-api/tests/integration_client_test.rs
+++ b/crates/unifly-api/tests/integration_client_test.rs
@@ -9,7 +9,8 @@ use wiremock::matchers::{method, path, query_param};
 use wiremock::{Mock, MockServer, ResponseTemplate};
 
 use unifly_api::integration_types::{
-    DeviceDetailsResponse, NetworkCreateUpdate, NetworkDetailsResponse, Page, SiteResponse,
+    DeviceDetailsResponse, FirewallPolicyResponse, NetworkCreateUpdate, NetworkDetailsResponse,
+    Page, SiteResponse,
 };
 use unifly_api::{ControllerPlatform, Error, IntegrationClient};
 
@@ -177,6 +178,56 @@ async fn test_delete_firewall_policy() {
         .delete_firewall_policy(&site_id, &policy_id)
         .await
         .unwrap();
+}
+
+#[tokio::test]
+async fn test_list_firewall_policies_accepts_legacy_policy_without_id() {
+    let (server, client) = setup().await;
+
+    let site_id = Uuid::new_v4();
+    let policy_id = Uuid::new_v4();
+    let body = json!({
+        "offset": 0,
+        "limit": 25,
+        "count": 2,
+        "totalCount": 2,
+        "data": [
+            {
+                "name": "Legacy migrated policy",
+                "enabled": true,
+                "action": {"type": "DROP"},
+                "loggingEnabled": true,
+                "index": 10001
+            },
+            {
+                "id": policy_id,
+                "name": "Modern policy",
+                "enabled": true,
+                "action": {"type": "ALLOW"},
+                "loggingEnabled": false
+            }
+        ]
+    });
+
+    Mock::given(method("GET"))
+        .and(path(format!(
+            "/integration/v1/sites/{site_id}/firewall/policies"
+        )))
+        .and(query_param("offset", "0"))
+        .and(query_param("limit", "25"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(&body))
+        .mount(&server)
+        .await;
+
+    let page: Page<FirewallPolicyResponse> = client
+        .list_firewall_policies(&site_id, 0, 25)
+        .await
+        .unwrap();
+
+    assert_eq!(page.total_count, 2);
+    assert_eq!(page.data.len(), 2);
+    assert_eq!(page.data[0].id, None);
+    assert_eq!(page.data[1].id, Some(policy_id));
 }
 
 #[tokio::test]


### PR DESCRIPTION
The Integration API returns pre-zone migrated user policies without an `id` field. The Vec parser failed on the first such record, dropping all policies silently via `unwrap_or_empty`.

This change:

- Makes `FirewallPolicyResponse.id` an `Option<Uuid>` so the response parses even when the id is missing.
- Synthesizes a deterministic `EntityId::Legacy("fwp:legacy:{src}:{dst}:{idx}:{name}")` for records that arrive without a UUID, so they remain addressable in `firewall policies list` and friends.
- Adds a unit test covering the IDless deserialize + synthesize path.

UUID-bearing rules are unchanged.

## Context

Affects controllers whose firewall_policy collection contains rules migrated from the pre-zone "rules" model (Network 7.x/8.x). Those migrated records sit in MongoDB without the `external_id` field that the Integration API uses to mint UUIDs, so the Integration GET returns them without an `id`. Verified against a live controller with 89 policies, 20 of which lacked UUIDs (all UserDefined pre-zone migrated rules); all 89 now visible via `firewall policies list`.

Write paths still require a UUID; `EntityId::Legacy` rules currently surface as read-only. A follow-up could route writes for those to the v2 endpoint using the synthesized key, but that is out of scope here.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for legacy firewall policies without IDs through automatic ID synthesis based on policy attributes.

* **Bug Fixes**
  * Improved validation to ensure integration responses include required policy identifiers; legacy policies without IDs are now handled with synthesized identifiers.

* **Tests**
  * Added integration tests for parsing legacy firewall policies without IDs.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/hyperb1iss/unifly/pull/24?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->