### PR TITLE
fix(api): parse real controller payload shapes for DNS and firewall

### DIFF
--- a/crates/unifly-api/src/controller/payloads/dns.rs
+++ b/crates/unifly-api/src/controller/payloads/dns.rs
@@ -348,6 +348,32 @@ mod tests {
     }
 
     #[test]
+    fn from_wire_accepts_every_serde_alias() {
+        // The serde alias list on DnsPolicyType and from_wire are two lenient
+        // input surfaces; every token one accepts, the other must too.
+        let aliases = [
+            ("A", DnsPolicyType::ARecord),
+            ("AAAA", DnsPolicyType::AaaaRecord),
+            ("CNAME", DnsPolicyType::CnameRecord),
+            ("MX", DnsPolicyType::MxRecord),
+            ("TXT", DnsPolicyType::TxtRecord),
+            ("SRV", DnsPolicyType::SrvRecord),
+            ("FORWARD", DnsPolicyType::ForwardDomain),
+            ("Forward", DnsPolicyType::ForwardDomain),
+        ];
+        for (token, expected) in aliases {
+            assert_eq!(
+                DnsPolicyType::from_wire(token),
+                Some(expected),
+                "from_wire must accept `{token}`"
+            );
+            let parsed: DnsPolicyType = serde_json::from_value(json!(token))
+                .unwrap_or_else(|_| panic!("serde must accept `{token}`"));
+            assert_eq!(parsed, expected, "serde alias for `{token}`");
+        }
+    }
+
+    #[test]
     fn dns_create_fields_use_type_specific_schema_keys() {
         let fields = build_create_dns_policy_fields(&CreateDnsPolicyRequest {
             name: "example.com".into(),

--- a/crates/unifly-api/src/controller/payloads/dns.rs
+++ b/crates/unifly-api/src/controller/payloads/dns.rs
@@ -2,27 +2,7 @@ use crate::core_error::CoreError;
 use crate::model::DnsPolicyType;
 
 pub(in super::super) fn dns_policy_type_name(policy_type: DnsPolicyType) -> &'static str {
-    match policy_type {
-        DnsPolicyType::ARecord => "A",
-        DnsPolicyType::AaaaRecord => "AAAA",
-        DnsPolicyType::CnameRecord => "CNAME",
-        DnsPolicyType::MxRecord => "MX",
-        DnsPolicyType::TxtRecord => "TXT",
-        DnsPolicyType::SrvRecord => "SRV",
-        DnsPolicyType::ForwardDomain => "FORWARD_DOMAIN",
-    }
-}
-
-fn dns_policy_type_from_name(policy_type: &str) -> DnsPolicyType {
-    match policy_type {
-        "A" => DnsPolicyType::ARecord,
-        "AAAA" => DnsPolicyType::AaaaRecord,
-        "CNAME" => DnsPolicyType::CnameRecord,
-        "MX" => DnsPolicyType::MxRecord,
-        "TXT" => DnsPolicyType::TxtRecord,
-        "SRV" => DnsPolicyType::SrvRecord,
-        _ => DnsPolicyType::ForwardDomain,
-    }
+    policy_type.wire_name()
 }
 
 fn validation_failed(message: impl Into<String>) -> CoreError {
@@ -95,7 +75,7 @@ fn ensure_dns_required_string(
         Ok(())
     } else {
         Err(validation_failed(format!(
-            "{policy_type:?} DNS policy requires `{key}`"
+            "{policy_type} DNS policy requires `{key}`"
         )))
     }
 }
@@ -113,7 +93,7 @@ fn ensure_dns_required_number(
         Ok(())
     } else {
         Err(validation_failed(format!(
-            "{policy_type:?} DNS policy requires `{key}`"
+            "{policy_type} DNS policy requires `{key}`"
         )))
     }
 }
@@ -244,7 +224,12 @@ pub(in super::super) fn build_update_dns_policy_fields(
     existing: &crate::integration_types::DnsPolicyResponse,
     update: &crate::command::UpdateDnsPolicyRequest,
 ) -> Result<serde_json::Map<String, serde_json::Value>, CoreError> {
-    let policy_type = dns_policy_type_from_name(&existing.policy_type);
+    let policy_type = DnsPolicyType::from_wire(&existing.policy_type).ok_or_else(|| {
+        validation_failed(format!(
+            "cannot update DNS policy with unrecognized record type `{}`",
+            existing.policy_type
+        ))
+    })?;
     let mut fields: serde_json::Map<String, serde_json::Value> =
         existing.extra.clone().into_iter().collect();
 
@@ -336,10 +321,31 @@ pub(in super::super) fn build_update_dns_policy_fields(
 
 #[cfg(test)]
 mod tests {
-    use super::build_create_dns_policy_fields;
+    use super::{build_create_dns_policy_fields, dns_policy_type_name};
     use crate::command::CreateDnsPolicyRequest;
     use crate::model::DnsPolicyType;
     use serde_json::json;
+
+    #[test]
+    fn dns_policy_type_names_use_wire_record_tokens() {
+        let cases = [
+            (DnsPolicyType::ARecord, "A_RECORD"),
+            (DnsPolicyType::AaaaRecord, "AAAA_RECORD"),
+            (DnsPolicyType::CnameRecord, "CNAME_RECORD"),
+            (DnsPolicyType::MxRecord, "MX_RECORD"),
+            (DnsPolicyType::TxtRecord, "TXT_RECORD"),
+            (DnsPolicyType::SrvRecord, "SRV_RECORD"),
+            (DnsPolicyType::ForwardDomain, "FORWARD_DOMAIN"),
+        ];
+        for (policy_type, wire) in cases {
+            assert_eq!(dns_policy_type_name(policy_type), wire);
+            assert_eq!(
+                DnsPolicyType::from_wire(wire),
+                Some(policy_type),
+                "round-trip for {wire}"
+            );
+        }
+    }
 
     #[test]
     fn dns_create_fields_use_type_specific_schema_keys() {

--- a/crates/unifly-api/src/controller/refresh/integration.rs
+++ b/crates/unifly-api/src/controller/refresh/integration.rs
@@ -93,7 +93,11 @@ pub(super) async fn fetch(
     let policies = unwrap_or_empty("firewall/policies", policies_res);
     let zones = unwrap_or_empty("firewall/zones", zones_res);
     let acls = unwrap_or_empty("acl/rules", acls_res);
-    let dns = unwrap_or_empty("dns/policies", dns_res);
+    let dns = unwrap_or_empty_with(
+        "dns/policies",
+        dns_res,
+        crate::convert::dns_policy_from_integration,
+    );
     let vouchers = unwrap_or_empty("vouchers", vouchers_res);
 
     info!(
@@ -180,8 +184,17 @@ fn unwrap_or_empty<S, D>(endpoint: &str, result: Result<Vec<S>, crate::error::Er
 where
     D: From<S>,
 {
+    unwrap_or_empty_with(endpoint, result, |item| Some(D::from(item)))
+}
+
+/// Like [`unwrap_or_empty`], for conversions that can reject individual items.
+fn unwrap_or_empty_with<S, D>(
+    endpoint: &str,
+    result: Result<Vec<S>, crate::error::Error>,
+    convert: impl Fn(S) -> Option<D>,
+) -> Vec<D> {
     match result {
-        Ok(items) => items.into_iter().map(D::from).collect(),
+        Ok(items) => items.into_iter().filter_map(convert).collect(),
         Err(ref error) if error.is_not_found() => {
             tracing::debug!("{endpoint}: not available (404), treating as empty");
             Vec::new()

--- a/crates/unifly-api/src/controller/refresh/integration.rs
+++ b/crates/unifly-api/src/controller/refresh/integration.rs
@@ -177,9 +177,9 @@ async fn fetch_device_statistics(
     .await
 }
 
-/// Downgrade a paginated result to an empty `Vec` when the endpoint returns 404.
-///
-/// Some Integration API endpoints are optional on older controller firmware.
+/// Downgrade a failed paginated fetch to an empty `Vec` so one optional
+/// endpoint cannot abort the whole refresh. 404s (endpoints missing on older
+/// firmware) log at debug; every other error logs at warn.
 fn unwrap_or_empty<S, D>(endpoint: &str, result: Result<Vec<S>, crate::error::Error>) -> Vec<D>
 where
     D: From<S>,

--- a/crates/unifly-api/src/convert/dns.rs
+++ b/crates/unifly-api/src/convert/dns.rs
@@ -73,6 +73,19 @@ fn dns_value_from_extra(policy_type: DnsPolicyType, extra: &HashMap<String, Valu
     }
 }
 
+/// Fallible public conversion for library consumers. Replaces the old
+/// infallible `From` impl, which mislabeled unknown record types as
+/// `ForwardDomain`; an unrecognized `type` token is now an error.
+impl TryFrom<integration_types::DnsPolicyResponse> for DnsPolicy {
+    type Error = String;
+
+    fn try_from(d: integration_types::DnsPolicyResponse) -> Result<Self, Self::Error> {
+        let policy_type = d.policy_type.clone();
+        dns_policy_from_integration(d)
+            .ok_or_else(|| format!("unrecognized DNS record type `{policy_type}`"))
+    }
+}
+
 pub(crate) fn dns_policy_from_integration(
     d: integration_types::DnsPolicyResponse,
 ) -> Option<DnsPolicy> {

--- a/crates/unifly-api/src/convert/dns.rs
+++ b/crates/unifly-api/src/convert/dns.rs
@@ -73,33 +73,32 @@ fn dns_value_from_extra(policy_type: DnsPolicyType, extra: &HashMap<String, Valu
     }
 }
 
-impl From<integration_types::DnsPolicyResponse> for DnsPolicy {
-    fn from(d: integration_types::DnsPolicyResponse) -> Self {
-        let policy_type = match d.policy_type.as_str() {
-            "A" => DnsPolicyType::ARecord,
-            "AAAA" => DnsPolicyType::AaaaRecord,
-            "CNAME" => DnsPolicyType::CnameRecord,
-            "MX" => DnsPolicyType::MxRecord,
-            "TXT" => DnsPolicyType::TxtRecord,
-            "SRV" => DnsPolicyType::SrvRecord,
-            _ => DnsPolicyType::ForwardDomain,
-        };
+pub(crate) fn dns_policy_from_integration(
+    d: integration_types::DnsPolicyResponse,
+) -> Option<DnsPolicy> {
+    let Some(policy_type) = DnsPolicyType::from_wire(&d.policy_type) else {
+        tracing::warn!(
+            policy_type = %d.policy_type,
+            id = %d.id,
+            "skipping DNS policy with unrecognized record type"
+        );
+        return None;
+    };
 
-        DnsPolicy {
-            id: EntityId::Uuid(d.id),
-            policy_type,
-            domain: d.domain.unwrap_or_default(),
-            value: dns_value_from_extra(policy_type, &d.extra),
-            #[allow(clippy::as_conversions, clippy::cast_possible_truncation)]
-            ttl_seconds: d
-                .extra
-                .get("ttlSeconds")
-                .and_then(serde_json::Value::as_u64)
-                .map(|t| t as u32),
-            origin: origin_from_metadata(&d.metadata),
-            source: DataSource::IntegrationApi,
-        }
-    }
+    Some(DnsPolicy {
+        id: EntityId::Uuid(d.id),
+        policy_type,
+        domain: d.domain.unwrap_or_default(),
+        value: dns_value_from_extra(policy_type, &d.extra),
+        #[allow(clippy::as_conversions, clippy::cast_possible_truncation)]
+        ttl_seconds: d
+            .extra
+            .get("ttlSeconds")
+            .and_then(serde_json::Value::as_u64)
+            .map(|t| t as u32),
+        origin: origin_from_metadata(&d.metadata),
+        source: DataSource::IntegrationApi,
+    })
 }
 
 #[cfg(test)]
@@ -109,22 +108,107 @@ mod tests {
     use super::*;
     use serde_json::json;
 
-    #[test]
-    fn integration_dns_policy_uses_type_specific_fields() {
-        let response = integration_types::DnsPolicyResponse {
+    fn response(
+        policy_type: &str,
+        extra: HashMap<String, Value>,
+    ) -> integration_types::DnsPolicyResponse {
+        integration_types::DnsPolicyResponse {
             id: uuid::Uuid::nil(),
-            policy_type: "A".into(),
+            policy_type: policy_type.into(),
             enabled: true,
             domain: Some("example.com".into()),
             metadata: json!({"origin": "USER"}),
-            extra: HashMap::from([
+            extra,
+        }
+    }
+
+    #[test]
+    fn integration_dns_policy_uses_type_specific_fields() {
+        let dns = dns_policy_from_integration(response(
+            "A_RECORD",
+            HashMap::from([
                 ("ipv4Address".into(), json!("192.168.1.10")),
                 ("ttlSeconds".into(), json!(600)),
             ]),
-        };
+        ))
+        .expect("known record type");
 
-        let dns = DnsPolicy::from(response);
+        assert_eq!(dns.policy_type, DnsPolicyType::ARecord);
         assert_eq!(dns.value, "192.168.1.10");
         assert_eq!(dns.ttl_seconds, Some(600));
+    }
+
+    #[test]
+    fn integration_dns_policy_extracts_value_for_every_record_type() {
+        let cases: [(&str, DnsPolicyType, HashMap<String, Value>, &str); 7] = [
+            (
+                "A_RECORD",
+                DnsPolicyType::ARecord,
+                HashMap::from([("ipv4Address".into(), json!("10.0.1.1"))]),
+                "10.0.1.1",
+            ),
+            (
+                "AAAA_RECORD",
+                DnsPolicyType::AaaaRecord,
+                HashMap::from([("ipv6Address".into(), json!("fd00::1"))]),
+                "fd00::1",
+            ),
+            (
+                "CNAME_RECORD",
+                DnsPolicyType::CnameRecord,
+                HashMap::from([("targetDomain".into(), json!("target.example.com"))]),
+                "target.example.com",
+            ),
+            (
+                "MX_RECORD",
+                DnsPolicyType::MxRecord,
+                HashMap::from([("mailServerDomain".into(), json!("mail.example.com"))]),
+                "mail.example.com",
+            ),
+            (
+                "TXT_RECORD",
+                DnsPolicyType::TxtRecord,
+                HashMap::from([("text".into(), json!("v=spf1 -all"))]),
+                "v=spf1 -all",
+            ),
+            (
+                "SRV_RECORD",
+                DnsPolicyType::SrvRecord,
+                HashMap::from([
+                    ("serverDomain".into(), json!("sip.example.com")),
+                    ("port".into(), json!(5060)),
+                ]),
+                "sip.example.com port=5060",
+            ),
+            (
+                "FORWARD_DOMAIN",
+                DnsPolicyType::ForwardDomain,
+                HashMap::from([("ipAddress".into(), json!("1.1.1.1"))]),
+                "1.1.1.1",
+            ),
+        ];
+
+        for (wire, expected_type, extra, expected_value) in cases {
+            let dns = dns_policy_from_integration(response(wire, extra))
+                .unwrap_or_else(|| panic!("{wire} should convert"));
+            assert_eq!(dns.policy_type, expected_type, "type for {wire}");
+            assert_eq!(dns.value, expected_value, "value for {wire}");
+        }
+    }
+
+    #[test]
+    fn integration_dns_policy_accepts_legacy_short_type_names() {
+        let dns = dns_policy_from_integration(response(
+            "A",
+            HashMap::from([("ipv4Address".into(), json!("10.0.1.1"))]),
+        ))
+        .expect("legacy short name");
+        assert_eq!(dns.policy_type, DnsPolicyType::ARecord);
+        assert_eq!(dns.value, "10.0.1.1");
+    }
+
+    #[test]
+    fn integration_dns_policy_skips_unknown_record_types() {
+        assert!(dns_policy_from_integration(response("PTR_RECORD", HashMap::new())).is_none());
     }
 }

--- a/crates/unifly-api/src/convert/dns.rs
+++ b/crates/unifly-api/src/convert/dns.rs
@@ -77,12 +77,11 @@ fn dns_value_from_extra(policy_type: DnsPolicyType, extra: &HashMap<String, Valu
 /// infallible `From` impl, which mislabeled unknown record types as
 /// `ForwardDomain`; an unrecognized `type` token is now an error.
 impl TryFrom<integration_types::DnsPolicyResponse> for DnsPolicy {
-    type Error = String;
+    type Error = crate::model::dns::UnrecognizedDnsRecordType;
 
     fn try_from(d: integration_types::DnsPolicyResponse) -> Result<Self, Self::Error> {
-        let policy_type = d.policy_type.clone();
-        dns_policy_from_integration(d)
-            .ok_or_else(|| format!("unrecognized DNS record type `{policy_type}`"))
+        let token = d.policy_type.clone();
+        dns_policy_from_integration(d).ok_or(crate::model::dns::UnrecognizedDnsRecordType { token })
     }
 }
 
@@ -103,12 +102,11 @@ pub(crate) fn dns_policy_from_integration(
         policy_type,
         domain: d.domain.unwrap_or_default(),
         value: dns_value_from_extra(policy_type, &d.extra),
-        #[allow(clippy::as_conversions, clippy::cast_possible_truncation)]
         ttl_seconds: d
             .extra
             .get("ttlSeconds")
             .and_then(serde_json::Value::as_u64)
-            .map(|t| t as u32),
+            .and_then(|t| u32::try_from(t).ok()),
         origin: origin_from_metadata(&d.metadata),
         source: DataSource::IntegrationApi,
     })

--- a/crates/unifly-api/src/convert/firewall.rs
+++ b/crates/unifly-api/src/convert/firewall.rs
@@ -334,6 +334,7 @@ fn convert_ip_address_filter(f: &integration_types::IpAddressFilter) -> Vec<IpSp
                 integration_types::IpAddressItem::Subnet { value } => IpSpec::Subnet {
                     value: value.clone(),
                 },
+                integration_types::IpAddressItem::Unknown => IpSpec::Address { value: "?".into() },
             })
             .collect(),
         integration_types::IpAddressFilter::TrafficMatchingList {

--- a/crates/unifly-api/src/convert/mod.rs
+++ b/crates/unifly-api/src/convert/mod.rs
@@ -13,6 +13,7 @@ mod supporting;
 mod wifi;
 
 pub(crate) use device::device_stats_from_integration;
+pub(crate) use dns::dns_policy_from_integration;
 pub use firewall::firewall_group_from_session;
 pub(crate) use interface::enrich_radios_from_stats;
 pub use nat::nat_policy_from_v2;

--- a/crates/unifly-api/src/integration/client.rs
+++ b/crates/unifly-api/src/integration/client.rs
@@ -364,8 +364,12 @@ impl IntegrationClient {
             fetched += i64::try_from(wire_received).unwrap_or(i64::MAX);
             all.extend(page.data);
 
+            // A zero-progress page terminates unconditionally: it covers a
+            // non-positive limit and servers that return empty pages with a
+            // positive totalCount, either of which would otherwise loop
+            // forever refetching offset 0.
             let limit_usize = usize::try_from(limit).unwrap_or(0);
-            if wire_received < limit_usize || fetched >= page.total_count {
+            if wire_received == 0 || wire_received < limit_usize || fetched >= page.total_count {
                 break;
             }
 

--- a/crates/unifly-api/src/integration/client.rs
+++ b/crates/unifly-api/src/integration/client.rs
@@ -350,20 +350,26 @@ impl IntegrationClient {
     {
         let mut all = Vec::new();
         let mut offset: i64 = 0;
+        let mut fetched: i64 = 0;
 
         loop {
             let page = fetch(offset, limit).await?;
-            let received = page.data.len();
+            // Pagination must advance by the number of items the server
+            // returned on the wire, not by `data.len()`: the lenient page
+            // decode drops unparseable items, and a dropped item on a full
+            // page would otherwise fake a short page and truncate the scan.
+            let wire_received = usize::try_from(page.count)
+                .unwrap_or(0)
+                .max(page.data.len());
+            fetched += i64::try_from(wire_received).unwrap_or(i64::MAX);
             all.extend(page.data);
 
             let limit_usize = usize::try_from(limit).unwrap_or(0);
-            if received < limit_usize
-                || i64::try_from(all.len()).unwrap_or(i64::MAX) >= page.total_count
-            {
+            if wire_received < limit_usize || fetched >= page.total_count {
                 break;
             }
 
-            offset += i64::try_from(received).unwrap_or(i64::MAX);
+            offset += i64::try_from(wire_received).unwrap_or(i64::MAX);
         }
 
         Ok(all)

--- a/crates/unifly-api/src/integration/types/common.rs
+++ b/crates/unifly-api/src/integration/types/common.rs
@@ -32,9 +32,12 @@ where
         .filter_map(|item| match serde_json::from_value::<T>(item) {
             Ok(parsed) => Some(parsed),
             Err(error) => {
+                // Log the error category only: serde_json messages can quote
+                // record field values, and controller records may carry
+                // hostnames or other data that must stay out of logs.
                 tracing::warn!(
                     item_type = std::any::type_name::<T>(),
-                    %error,
+                    category = ?error.classify(),
                     "skipping list item that failed to parse"
                 );
                 None

--- a/crates/unifly-api/src/integration/types/common.rs
+++ b/crates/unifly-api/src/integration/types/common.rs
@@ -5,14 +5,42 @@ use serde_json::Value;
 use uuid::Uuid;
 
 /// Generic pagination wrapper returned by all list endpoints.
+///
+/// Items are decoded individually: a record the model cannot parse is
+/// dropped with a warning instead of failing the whole page, so one
+/// unexpected payload shape cannot blank an entire collection.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
+#[serde(bound(deserialize = "T: serde::de::DeserializeOwned"))]
 pub struct Page<T> {
     pub offset: i64,
     pub limit: i32,
     pub count: i32,
     pub total_count: i64,
+    #[serde(deserialize_with = "lenient_items")]
     pub data: Vec<T>,
+}
+
+fn lenient_items<'de, D, T>(deserializer: D) -> Result<Vec<T>, D::Error>
+where
+    D: serde::Deserializer<'de>,
+    T: serde::de::DeserializeOwned,
+{
+    let raw = Vec::<Value>::deserialize(deserializer)?;
+    Ok(raw
+        .into_iter()
+        .filter_map(|item| match serde_json::from_value::<T>(item) {
+            Ok(parsed) => Some(parsed),
+            Err(error) => {
+                tracing::warn!(
+                    item_type = std::any::type_name::<T>(),
+                    %error,
+                    "skipping list item that failed to parse"
+                );
+                None
+            }
+        })
+        .collect())
 }
 
 /// Site overview — from `GET /v1/sites`.

--- a/crates/unifly-api/src/integration/types/policy.rs
+++ b/crates/unifly-api/src/integration/types/policy.rs
@@ -8,6 +8,7 @@ use uuid::Uuid;
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct FirewallPolicySource {
+    #[serde(default)]
     pub zone_id: Option<Uuid>,
     #[serde(default)]
     pub traffic_filter: Option<SourceTrafficFilter>,
@@ -17,6 +18,7 @@ pub struct FirewallPolicySource {
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct FirewallPolicyDestination {
+    #[serde(default)]
     pub zone_id: Option<Uuid>,
     #[serde(default)]
     pub traffic_filter: Option<DestTrafficFilter>,
@@ -206,6 +208,8 @@ pub enum IpAddressItem {
     Range { start: String, stop: String },
     #[serde(rename = "SUBNET")]
     Subnet { value: String },
+    #[serde(other)]
+    Unknown,
 }
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
@@ -239,9 +243,20 @@ pub enum PortItem {
     },
     #[serde(rename = "PORT_NUMBER_RANGE", alias = "PORT_RANGE")]
     Range {
-        #[serde(rename = "startPort", deserialize_with = "deserialize_port_value")]
+        // The controller sends `start`/`stop` (per the OpenAPI schema
+        // `Number range port matching`); `startPort`/`endPort` is kept as
+        // the serialization shape the write path has been tested with.
+        #[serde(
+            rename = "startPort",
+            alias = "start",
+            deserialize_with = "deserialize_port_value"
+        )]
         start_port: String,
-        #[serde(rename = "endPort", deserialize_with = "deserialize_port_value")]
+        #[serde(
+            rename = "endPort",
+            alias = "stop",
+            deserialize_with = "deserialize_port_value"
+        )]
         end_port: String,
     },
     #[serde(other)]
@@ -643,5 +658,41 @@ mod tests {
             matches!(item, PortItem::Range { .. }),
             "PORT_RANGE alias must still deserialize"
         );
+    }
+
+    #[test]
+    fn port_item_range_deserializes_from_spec_start_stop_fields() {
+        // The wire shape per the OpenAPI `Number range port matching` schema
+        // and the controller behavior reported in issue #26.
+        let item: PortItem = serde_json::from_value(serde_json::json!({
+            "type": "PORT_NUMBER_RANGE",
+            "start": 8000,
+            "stop": 9000
+        }))
+        .unwrap();
+        assert_eq!(
+            item,
+            PortItem::Range {
+                start_port: "8000".into(),
+                end_port: "9000".into()
+            }
+        );
+    }
+
+    #[test]
+    fn ip_address_item_tolerates_unknown_type() {
+        let filter: IpAddressFilter = serde_json::from_value(serde_json::json!({
+            "type": "SPECIFIC",
+            "items": [{ "type": "GEOIP_FANCY_FUTURE", "value": "whatever" }],
+            "matchOpposite": false
+        }))
+        .unwrap();
+
+        match filter {
+            IpAddressFilter::Specific { items, .. } => {
+                assert_eq!(items, vec![super::IpAddressItem::Unknown]);
+            }
+            other => panic!("unexpected filter: {other:?}"),
+        }
     }
 }

--- a/crates/unifly-api/src/model/dns.rs
+++ b/crates/unifly-api/src/model/dns.rs
@@ -1,5 +1,7 @@
 // ── DNS domain types ──
 
+use std::fmt;
+
 use serde::{Deserialize, Serialize};
 
 use super::common::{DataSource, EntityOrigin};
@@ -7,13 +9,67 @@ use super::entity_id::EntityId;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 pub enum DnsPolicyType {
+    #[serde(alias = "A_RECORD", alias = "A")]
     ARecord,
+    #[serde(alias = "AAAA_RECORD", alias = "AAAA")]
     AaaaRecord,
+    #[serde(alias = "CNAME_RECORD", alias = "CNAME")]
     CnameRecord,
+    #[serde(alias = "MX_RECORD", alias = "MX")]
     MxRecord,
+    #[serde(alias = "TXT_RECORD", alias = "TXT")]
     TxtRecord,
+    #[serde(alias = "SRV_RECORD", alias = "SRV")]
     SrvRecord,
+    #[serde(alias = "FORWARD_DOMAIN", alias = "Forward")]
     ForwardDomain,
+}
+
+impl DnsPolicyType {
+    /// The `type` token the Integration API uses on the wire.
+    #[must_use]
+    pub fn wire_name(self) -> &'static str {
+        match self {
+            Self::ARecord => "A_RECORD",
+            Self::AaaaRecord => "AAAA_RECORD",
+            Self::CnameRecord => "CNAME_RECORD",
+            Self::MxRecord => "MX_RECORD",
+            Self::TxtRecord => "TXT_RECORD",
+            Self::SrvRecord => "SRV_RECORD",
+            Self::ForwardDomain => "FORWARD_DOMAIN",
+        }
+    }
+
+    /// Parse a wire `type` token, accepting both the `*_RECORD` form and the
+    /// bare short form some firmware variants emit.
+    #[must_use]
+    pub fn from_wire(name: &str) -> Option<Self> {
+        match name {
+            "A_RECORD" | "A" => Some(Self::ARecord),
+            "AAAA_RECORD" | "AAAA" => Some(Self::AaaaRecord),
+            "CNAME_RECORD" | "CNAME" => Some(Self::CnameRecord),
+            "MX_RECORD" | "MX" => Some(Self::MxRecord),
+            "TXT_RECORD" | "TXT" => Some(Self::TxtRecord),
+            "SRV_RECORD" | "SRV" => Some(Self::SrvRecord),
+            "FORWARD_DOMAIN" | "FORWARD" => Some(Self::ForwardDomain),
+            _ => None,
+        }
+    }
+}
+
+impl fmt::Display for DnsPolicyType {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let name = match self {
+            Self::ARecord => "A",
+            Self::AaaaRecord => "AAAA",
+            Self::CnameRecord => "CNAME",
+            Self::MxRecord => "MX",
+            Self::TxtRecord => "TXT",
+            Self::SrvRecord => "SRV",
+            Self::ForwardDomain => "Forward",
+        };
+        f.write_str(name)
+    }
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/crates/unifly-api/src/model/dns.rs
+++ b/crates/unifly-api/src/model/dns.rs
@@ -21,7 +21,7 @@ pub enum DnsPolicyType {
     TxtRecord,
     #[serde(alias = "SRV_RECORD", alias = "SRV")]
     SrvRecord,
-    #[serde(alias = "FORWARD_DOMAIN", alias = "Forward")]
+    #[serde(alias = "FORWARD_DOMAIN", alias = "FORWARD", alias = "Forward")]
     ForwardDomain,
 }
 

--- a/crates/unifly-api/src/model/dns.rs
+++ b/crates/unifly-api/src/model/dns.rs
@@ -51,10 +51,17 @@ impl DnsPolicyType {
             "MX_RECORD" | "MX" => Some(Self::MxRecord),
             "TXT_RECORD" | "TXT" => Some(Self::TxtRecord),
             "SRV_RECORD" | "SRV" => Some(Self::SrvRecord),
-            "FORWARD_DOMAIN" | "FORWARD" => Some(Self::ForwardDomain),
+            "FORWARD_DOMAIN" | "FORWARD" | "Forward" => Some(Self::ForwardDomain),
             _ => None,
         }
     }
+}
+
+/// A DNS policy carried a `type` token no known mapping recognizes.
+#[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
+#[error("unrecognized DNS record type `{token}`")]
+pub struct UnrecognizedDnsRecordType {
+    pub token: String,
 }
 
 impl fmt::Display for DnsPolicyType {

--- a/crates/unifly-api/tests/controller_runtime_test.rs
+++ b/crates/unifly-api/tests/controller_runtime_test.rs
@@ -15,6 +15,7 @@ use url::Url;
 use wiremock::matchers::{method, path};
 use wiremock::{Mock, MockServer, ResponseTemplate};
 
+use unifly_api::model::DnsPolicyType;
 use unifly_api::{
     AuthCredentials, Controller, ControllerConfig, ControllerPlatform, CoreError, Error,
     MacAddress, SessionClient, TlsVerification, TransportConfig,
@@ -231,7 +232,7 @@ async fn mount_api_key_integration_routes(server: &MockServer) {
         ),
         (
             format!("/proxy/network/integration/v1/sites/{API_KEY_SITE_ID}/dns/policies"),
-            empty_integration_page(200),
+            dns_policies_page(),
         ),
         (
             format!("/proxy/network/integration/v1/sites/{API_KEY_SITE_ID}/vouchers"),
@@ -248,6 +249,34 @@ async fn mount_api_key_integration_routes(server: &MockServer) {
             .mount(server)
             .await;
     }
+}
+
+fn dns_policies_page() -> serde_json::Value {
+    json!({
+        "offset": 0,
+        "limit": 200,
+        "count": 2,
+        "totalCount": 2,
+        "data": [
+            {
+                "type": "A_RECORD",
+                "id": "0ce73be5-f734-4b24-aac2-d91dbe88202d",
+                "enabled": true,
+                "metadata": {"origin": "USER_DEFINED"},
+                "domain": "unifi.example.net",
+                "ipv4Address": "10.0.1.1",
+                "ttlSeconds": 0,
+            },
+            {
+                "type": "FORWARD_DOMAIN",
+                "id": "1df84cf6-0845-4c35-bbd3-e02ecf99313e",
+                "enabled": true,
+                "metadata": {"origin": "USER_DEFINED"},
+                "domain": "corp.example.net",
+                "ipAddress": "10.0.9.53",
+            },
+        ],
+    })
 }
 
 fn api_key_event_envelope() -> serde_json::Value {
@@ -439,6 +468,22 @@ async fn api_key_mode_has_legacy_and_integration_access() {
     assert_eq!(client.hostname.as_deref(), Some("test-host"));
     assert_eq!(client.tx_bytes, Some(1234));
     assert_eq!(client.rx_bytes, Some(5678));
+
+    let dns = controller.dns_policies_snapshot();
+    assert_eq!(dns.len(), 2);
+    let a_record = dns
+        .iter()
+        .find(|d| d.domain == "unifi.example.net")
+        .expect("A record present");
+    assert_eq!(a_record.policy_type, DnsPolicyType::ARecord);
+    assert_eq!(a_record.value, "10.0.1.1");
+    assert_eq!(a_record.ttl_seconds, Some(0));
+    let forward = dns
+        .iter()
+        .find(|d| d.domain == "corp.example.net")
+        .expect("forward domain present");
+    assert_eq!(forward.policy_type, DnsPolicyType::ForwardDomain);
+    assert_eq!(forward.value, "10.0.9.53");
 
     let received = server.received_requests().await.unwrap();
     let legacy_reqs: Vec<_> = received

--- a/crates/unifly-api/tests/integration_client_test.rs
+++ b/crates/unifly-api/tests/integration_client_test.rs
@@ -78,6 +78,61 @@ async fn test_list_sites_pagination() {
 }
 
 #[tokio::test]
+async fn test_paginate_all_advances_past_dropped_items() {
+    let (server, client) = setup().await;
+
+    let site_a = Uuid::new_v4();
+    let site_b = Uuid::new_v4();
+
+    // Page 1 is full on the wire (count == limit) but one item is malformed
+    // and gets dropped by the lenient decode. Pagination must still fetch
+    // page 2 and advance the offset by the wire count, not the kept count.
+    let page1 = json!({
+        "offset": 0,
+        "limit": 2,
+        "count": 2,
+        "totalCount": 3,
+        "data": [
+            { "id": site_a, "name": "Main", "internalReference": "default" },
+            { "id": "not-a-uuid", "name": 42 },
+        ]
+    });
+    let page2 = json!({
+        "offset": 2,
+        "limit": 2,
+        "count": 1,
+        "totalCount": 3,
+        "data": [
+            { "id": site_b, "name": "Remote", "internalReference": "site2" },
+        ]
+    });
+
+    Mock::given(method("GET"))
+        .and(path("/integration/v1/sites"))
+        .and(query_param("offset", "0"))
+        .and(query_param("limit", "2"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(&page1))
+        .mount(&server)
+        .await;
+    Mock::given(method("GET"))
+        .and(path("/integration/v1/sites"))
+        .and(query_param("offset", "2"))
+        .and(query_param("limit", "2"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(&page2))
+        .mount(&server)
+        .await;
+
+    let sites: Vec<SiteResponse> = client
+        .paginate_all(2, |offset, limit| client.list_sites(offset, limit))
+        .await
+        .unwrap();
+
+    assert_eq!(sites.len(), 2, "good items from both pages must survive");
+    assert_eq!(sites[0].name, "Main");
+    assert_eq!(sites[1].name, "Remote");
+}
+
+#[tokio::test]
 async fn test_get_device() {
     let (server, client) = setup().await;
 

--- a/crates/unifly-api/tests/integration_client_test.rs
+++ b/crates/unifly-api/tests/integration_client_test.rs
@@ -231,6 +231,79 @@ async fn test_list_firewall_policies_accepts_legacy_policy_without_id() {
 }
 
 #[tokio::test]
+async fn test_list_firewall_policies_survives_spec_port_range_and_bad_items() {
+    let (server, client) = setup().await;
+
+    let site_id = Uuid::new_v4();
+    // Policy 2 carries the `start`/`stop` range shape UniFi OS actually sends
+    // (issue #26); policy 3 is malformed and must be dropped, not fatal.
+    let body = json!({
+        "offset": 0,
+        "limit": 25,
+        "count": 3,
+        "totalCount": 3,
+        "data": [
+            {
+                "id": Uuid::new_v4(),
+                "name": "Allow HTTP from Trusted",
+                "enabled": true,
+                "action": {"type": "ALLOW"},
+                "loggingEnabled": false
+            },
+            {
+                "id": Uuid::new_v4(),
+                "name": "Allow range",
+                "enabled": true,
+                "action": {"type": "ALLOW"},
+                "loggingEnabled": false,
+                "destination": {
+                    "zoneId": Uuid::new_v4(),
+                    "trafficFilter": {
+                        "type": "NETWORK",
+                        "networkFilter": {"networkIds": [], "matchOpposite": false},
+                        "portFilter": {
+                            "type": "PORTS",
+                            "matchOpposite": false,
+                            "items": [
+                                {"type": "PORT_NUMBER_RANGE", "start": 8000, "stop": 9000}
+                            ]
+                        }
+                    }
+                }
+            },
+            {
+                "id": Uuid::new_v4(),
+                "enabled": "definitely-not-a-bool"
+            }
+        ]
+    });
+
+    Mock::given(method("GET"))
+        .and(path(format!(
+            "/integration/v1/sites/{site_id}/firewall/policies"
+        )))
+        .and(query_param("offset", "0"))
+        .and(query_param("limit", "25"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(&body))
+        .mount(&server)
+        .await;
+
+    let page: Page<FirewallPolicyResponse> = client
+        .list_firewall_policies(&site_id, 0, 25)
+        .await
+        .unwrap();
+
+    assert_eq!(page.total_count, 3);
+    assert_eq!(
+        page.data.len(),
+        2,
+        "malformed item must be dropped without failing the page"
+    );
+    assert_eq!(page.data[0].name, "Allow HTTP from Trusted");
+    assert_eq!(page.data[1].name, "Allow range");
+}
+
+#[tokio::test]
 async fn test_get_firewall_policy_ordering_uses_zone_pair_query_params() {
     let (server, client) = setup().await;
 

--- a/crates/unifly/src/cli/commands/dns.rs
+++ b/crates/unifly/src/cli/commands/dns.rs
@@ -45,7 +45,7 @@ struct DnsRow {
 fn dns_row(d: &Arc<DnsPolicy>, p: &output::Painter) -> DnsRow {
     DnsRow {
         id: p.id(&d.id.to_string()),
-        record_type: p.muted(&format!("{:?}", d.policy_type)),
+        record_type: p.muted(&d.policy_type.to_string()),
         domain: p.name(&d.domain),
         value: p.ip(&d.value),
         ttl: p.number(&d.ttl_seconds.map(|t| t.to_string()).unwrap_or_default()),
@@ -55,7 +55,7 @@ fn dns_row(d: &Arc<DnsPolicy>, p: &output::Painter) -> DnsRow {
 fn detail(d: &Arc<DnsPolicy>) -> String {
     [
         format!("ID:     {}", d.id),
-        format!("Type:   {:?}", d.policy_type),
+        format!("Type:   {}", d.policy_type),
         format!("Domain: {}", d.domain),
         format!("Value:  {}", d.value),
         format!(


### PR DESCRIPTION
## 🎯 What

Fixes the two open deserialization bugs against real UniFi OS controllers and hardens the Integration list path so a single unexpected record can never blank a whole collection again.

Closes #27. Closes #26.

## 🔍 Why

Both issues share one root class: hand-written wire-shape assumptions that drifted from what controllers actually send, combined with all-or-nothing decoding that turned one surprising record into an empty table.

**DNS (#27):** the Integration API identifies DNS policies with `A_RECORD` / `AAAA_RECORD` / `FORWARD_DOMAIN` style tokens. Three separate mapping tables in the codebase expected bare short names (`"A"`, `"AAAA"`) with a silent fallthrough to `ForwardDomain`, so every non-forward record on a modern controller rendered as `ForwardDomain` with an empty value (value extraction looked up `ipAddress` instead of the type-specific field). The same tables fed `dns create` (emitting a token the controller rejects) and `dns update` (misclassifying existing records and failing validation with a misleading error).

**Firewall (#26):** UniFi OS sends port ranges as `{"start": N, "stop": N}`, matching the vendored OpenAPI schema `Number range port matching`; the string `startPort` appears nowhere in Ubiquiti's spec. `PortItem::Range` demanded `startPort`/`endPort`, so one policy carrying a port range failed deserialization, and because `Page<T>` decoded all-or-nothing, that one policy collapsed the reporter's 109-policy list into an empty table with only a WARN line.

## 🛠️ How

- `DnsPolicyType` now owns one canonical bidirectional mapping: `wire_name()` emits the `*_RECORD` tokens, `from_wire()` accepts both the modern and bare short forms. All three former tables delegate to it. Records with an unrecognized type are skipped with a warning instead of mislabeled, updates on them fail with an explicit validation error, and the CLI renders record types as short DNS names (`A`, `CNAME`, `Forward`) via a new `Display` impl. Serde aliases keep `--from-file` payloads working with any of the three spellings.
- `PortItem::Range` accepts `start`/`stop` via serde aliases while still serializing the `startPort`/`endPort` shape the tested write path uses. `zoneId` may arrive absent on source/destination (serde default), and an unrecognized `IpAddressItem` type maps to `Unknown` instead of erroring.
- `Page<T>` decodes items individually: a record the model cannot parse is dropped with a warning, so one unexpected payload shape cannot blank a collection. Pagination advances by the server-reported per-page `count` (floored at `data.len()`), because a dropped item on a full page would otherwise fake a short page and silently truncate the scan.

## 🧪 Testing

- The reporter's exact `A_RECORD` payload from #27 flows through a wiremock refresh test and asserts type, value, and TTL.
- Unit tests cover value extraction for all seven record types, legacy short names, unknown-type skipping, and wire-token round-trips.
- A wiremock test feeds a page with a spec-shaped port range plus a deliberately malformed policy and asserts the good records survive.
- A two-page pagination test puts a malformed item on a full first page and asserts items from both pages are returned.
- `just check` (fmt, maintainability, clippy, full test suite) passes: unifly-api 154 lib + 23 integration + 32 session + 10 runtime tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * DNS policies now correctly recognize canonical, short, and legacy record-type names.
  * Unknown DNS record types produce validation errors instead of being misclassified.
  * Malformed API records no longer prevent valid records from loading or disrupt pagination.
  * Firewall policy data now supports additional port-range formats and missing zone values.
  * Unknown IP filter items remain visible instead of being silently omitted.

* **Improvements**
  * DNS policy types display with clearer, user-friendly names in tables and details.
  * Added broader coverage for DNS, firewall, pagination, and runtime API behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->