### PR TITLE
fix(tui): honor CLI overrides and surface connect failures

### DIFF
--- a/crates/unifly/src/bin/cli.rs
+++ b/crates/unifly/src/bin/cli.rs
@@ -195,7 +195,7 @@ async fn build_controller_config(
         auth,
         site: global.site.clone().unwrap_or_else(|| "default".into()),
         tls,
-        timeout: std::time::Duration::from_secs(global.timeout),
+        timeout: std::time::Duration::from_secs(global.timeout_secs(None)),
         refresh_interval_secs: 0,
         websocket_enabled: false,
         polling_interval_secs: 30,

--- a/crates/unifly/src/cli/args/common.rs
+++ b/crates/unifly/src/cli/args/common.rs
@@ -79,19 +79,6 @@ pub struct GlobalOpts {
     pub no_effects: bool,
 }
 
-/// Fallback request timeout when neither `--timeout` nor the profile sets one.
-pub const DEFAULT_TIMEOUT_SECS: u64 = 30;
-
-impl GlobalOpts {
-    /// Resolve the effective timeout: flag/env, then profile, then default.
-    #[must_use]
-    pub fn timeout_secs(&self, profile_timeout: Option<u64>) -> u64 {
-        self.timeout
-            .or(profile_timeout)
-            .unwrap_or(DEFAULT_TIMEOUT_SECS)
-    }
-}
-
 #[derive(Debug, Clone, ValueEnum)]
 pub enum OutputFormat {
     /// Pretty table (default, interactive)

--- a/crates/unifly/src/cli/args/common.rs
+++ b/crates/unifly/src/cli/args/common.rs
@@ -70,13 +70,26 @@ pub struct GlobalOpts {
     #[arg(long, short = 'k', env = "UNIFI_INSECURE", global = true)]
     pub insecure: bool,
 
-    /// Request timeout in seconds
-    #[arg(long, env = "UNIFI_TIMEOUT", default_value = "30", global = true)]
-    pub timeout: u64,
+    /// Request timeout in seconds (default 30, profiles may override)
+    #[arg(long, env = "UNIFI_TIMEOUT", global = true)]
+    pub timeout: Option<u64>,
 
     /// Disable tachyonfx animations in the TUI (honours `NO_EFFECTS=1`)
     #[arg(long, global = true)]
     pub no_effects: bool,
+}
+
+/// Fallback request timeout when neither `--timeout` nor the profile sets one.
+pub const DEFAULT_TIMEOUT_SECS: u64 = 30;
+
+impl GlobalOpts {
+    /// Resolve the effective timeout: flag/env, then profile, then default.
+    #[must_use]
+    pub fn timeout_secs(&self, profile_timeout: Option<u64>) -> u64 {
+        self.timeout
+            .or(profile_timeout)
+            .unwrap_or(DEFAULT_TIMEOUT_SECS)
+    }
 }
 
 #[derive(Debug, Clone, ValueEnum)]

--- a/crates/unifly/src/cli/commands/cloud.rs
+++ b/crates/unifly/src/cli/commands/cloud.rs
@@ -42,7 +42,7 @@ pub(crate) fn build_site_manager_client(
 
     let api_key = resolve_cloud_api_key(profile.as_ref(), &profile_name, global)?;
     let controller = resolve_site_manager_url(profile.as_ref(), global);
-    let transport = cloud_transport(global);
+    let transport = cloud_transport(global, profile.as_ref().and_then(|p| p.timeout));
 
     SiteManagerClient::from_api_key(&controller, &api_key, &transport).map_err(api_error)
 }
@@ -64,7 +64,7 @@ pub(crate) async fn build_cloud_integration_client(
 ) -> Result<IntegrationClient, CliError> {
     let api_key = resolve_cloud_api_key(Some(profile), profile_name, global)?;
     let controller = resolve_site_manager_url(Some(profile), global);
-    let transport = cloud_transport(global);
+    let transport = cloud_transport(global, profile.timeout);
     let host_id = if let Some(host_id) = &global.host_id {
         host_id.clone()
     } else if let Ok(host_id) = config::resolve_host_id(profile) {
@@ -104,10 +104,10 @@ pub(crate) fn active_profile(global: &GlobalOpts) -> (String, Option<Profile>) {
     (profile_name, profile)
 }
 
-fn cloud_transport(global: &GlobalOpts) -> TransportConfig {
+fn cloud_transport(global: &GlobalOpts, profile_timeout: Option<u64>) -> TransportConfig {
     TransportConfig {
         tls: TlsMode::System,
-        timeout: Duration::from_secs(global.timeout_secs(None)),
+        timeout: Duration::from_secs(global.timeout_secs(profile_timeout)),
         cookie_jar: None,
     }
 }

--- a/crates/unifly/src/cli/commands/cloud.rs
+++ b/crates/unifly/src/cli/commands/cloud.rs
@@ -107,7 +107,7 @@ pub(crate) fn active_profile(global: &GlobalOpts) -> (String, Option<Profile>) {
 fn cloud_transport(global: &GlobalOpts) -> TransportConfig {
     TransportConfig {
         tls: TlsMode::System,
-        timeout: Duration::from_secs(global.timeout),
+        timeout: Duration::from_secs(global.timeout_secs(None)),
         cookie_jar: None,
     }
 }

--- a/crates/unifly/src/cli/commands/config_cmd/interactive.rs
+++ b/crates/unifly/src/cli/commands/config_cmd/interactive.rs
@@ -664,8 +664,11 @@ pub(super) async fn run_cloud_setup(global: &GlobalOpts) -> Result<(), CliError>
     eprintln!();
 
     let api_key_setup = prompt_cloud_api_key(&ui)?;
-    let site_manager =
-        build_site_manager_client(&controller, &api_key_setup.secret, global.timeout)?;
+    let site_manager = build_site_manager_client(
+        &controller,
+        &api_key_setup.secret,
+        global.timeout_secs(None),
+    )?;
 
     ui.step("Checking which consoles this API key can see...");
     let hosts = site_manager.list_hosts().await.map_err(cloud_api_error)?;
@@ -679,7 +682,7 @@ pub(super) async fn run_cloud_setup(global: &GlobalOpts) -> Result<(), CliError>
         &controller,
         &host.id,
         &api_key_setup.secret,
-        global.timeout,
+        global.timeout_secs(None),
     )?;
     let sites = integration
         .paginate_all(50, |offset, limit| integration.list_sites(offset, limit))

--- a/crates/unifly/src/cli/commands/devices/render.rs
+++ b/crates/unifly/src/cli/commands/devices/render.rs
@@ -621,7 +621,7 @@ mod tests {
             quiet: false,
             yes: false,
             insecure: false,
-            timeout: 30,
+            timeout: None,
             no_effects: false,
         })
     }

--- a/crates/unifly/src/config/resolve.rs
+++ b/crates/unifly/src/config/resolve.rs
@@ -18,6 +18,22 @@ pub use crate::config::{Defaults, config_path, load_config_or_default, save_conf
 
 // ── CLI-specific helpers ────────────────────────────────────────
 
+/// Fallback request timeout when neither `--timeout` nor the profile sets one.
+pub const DEFAULT_TIMEOUT_SECS: u64 = 30;
+
+// This inherent impl lives here rather than in `cli/args/common.rs`
+// because build.rs includes args.rs standalone for man-page generation,
+// and that compilation unit must stay pure clap definitions.
+impl GlobalOpts {
+    /// Resolve the effective timeout: flag/env, then profile, then default.
+    #[must_use]
+    pub fn timeout_secs(&self, profile_timeout: Option<u64>) -> u64 {
+        self.timeout
+            .or(profile_timeout)
+            .unwrap_or(DEFAULT_TIMEOUT_SECS)
+    }
+}
+
 /// Resolve the active profile name from CLI flags and config.
 pub fn active_profile_name(global: &GlobalOpts, cfg: &Config) -> String {
     global

--- a/crates/unifly/src/config/resolve.rs
+++ b/crates/unifly/src/config/resolve.rs
@@ -217,6 +217,25 @@ mod tests {
     }
 
     #[test]
+    fn resolve_profile_honors_insecure_flag_over_unset_profile() {
+        // The TUI launch path resolves profiles through this function; the
+        // -k/--insecure flag must win when the profile leaves TLS unset
+        // (issue #25: flag was dropped, TLS failed, TUI sat disconnected).
+        let mut profile = cloud_profile();
+        profile.auth_mode = "integration".into();
+        profile.controller = "https://10.0.1.1".into();
+        profile.insecure = None;
+
+        let global = base_global();
+        assert!(global.insecure);
+
+        let resolved =
+            resolve_profile(&profile, "default", &global).expect("profile should resolve");
+
+        assert!(matches!(resolved.tls, TlsVerification::DangerAcceptInvalid));
+    }
+
+    #[test]
     fn resolve_profile_cloud_requires_host_id() {
         let profile = cloud_profile();
         let mut global = base_global();

--- a/crates/unifly/src/config/resolve.rs
+++ b/crates/unifly/src/config/resolve.rs
@@ -98,8 +98,8 @@ pub fn resolve_profile(
     // 4. Site (flag > env > profile)
     let site = global.site.as_deref().unwrap_or(&profile.site).to_string();
 
-    // 5. Timeout
-    let timeout = Duration::from_secs(global.timeout);
+    // 5. Timeout (flag/env > profile > default)
+    let timeout = Duration::from_secs(global.timeout_secs(profile.timeout));
 
     // 6. TOTP (flag > env var from profile's totp_env)
     let totp_token = resolve_totp_with_flag(profile, global);
@@ -173,7 +173,7 @@ mod tests {
             no_cache: false,
             demo: false,
             insecure: true,
-            timeout: 30,
+            timeout: None,
             no_effects: false,
         }
     }

--- a/crates/unifly/src/tui/app.rs
+++ b/crates/unifly/src/tui/app.rs
@@ -53,6 +53,8 @@ pub struct App {
     running: bool,
     /// Connection status indicator.
     connection_status: ConnectionStatus,
+    /// Why the last connect attempt failed, shown next to the indicator.
+    connection_error: Option<String>,
     /// Help overlay visibility.
     help_visible: bool,
     /// About overlay visibility.
@@ -129,6 +131,7 @@ impl App {
             screens,
             running: true,
             connection_status: ConnectionStatus::default(),
+            connection_error: None,
             help_visible: false,
             about_visible: false,
             search_active: false,

--- a/crates/unifly/src/tui/app/dispatch.rs
+++ b/crates/unifly/src/tui/app/dispatch.rs
@@ -55,9 +55,14 @@ impl App {
             }
             Action::Connected => {
                 self.connection_status = ConnectionStatus::Connected;
+                self.connection_error = None;
             }
-            Action::Disconnected(_) => {
+            Action::Disconnected(reason) => {
                 self.connection_status = ConnectionStatus::Disconnected;
+                self.show_notification(crate::tui::action::Notification::error(format!(
+                    "connection failed: {reason}"
+                )));
+                self.connection_error = Some(reason.clone());
             }
             Action::Reconnecting => {
                 self.connection_status = ConnectionStatus::Reconnecting;

--- a/crates/unifly/src/tui/app/render.rs
+++ b/crates/unifly/src/tui/app/render.rs
@@ -149,12 +149,20 @@ impl App {
         if matches!(self.connection_status, ConnectionStatus::Disconnected)
             && let Some(reason) = &self.connection_error
         {
-            let max = usize::from(area.width).saturating_sub(60).max(24);
-            let short: String = reason.chars().take(max).collect();
-            spans.push(Span::styled(
-                format!(" ({short})"),
-                Style::default().fg(theme::error()),
-            ));
+            // The reason is best-effort context: it must never displace the
+            // key hints or run under the sponsor button. Budget from the
+            // actual fixed-span widths and drop it when it cannot fit.
+            let donate_width = if self.show_donate { 12 } else { 0 };
+            let fixed: usize =
+                spans.iter().map(Span::width).sum::<usize>() + hints.width() + 3 + donate_width;
+            let budget = usize::from(area.width).saturating_sub(fixed);
+            if budget >= 12 {
+                let short: String = reason.chars().take(budget).collect();
+                spans.push(Span::styled(
+                    format!(" ({short})"),
+                    Style::default().fg(theme::error()),
+                ));
+            }
         }
         spans.push(hints);
         let line = Line::from(spans);

--- a/crates/unifly/src/tui/app/render.rs
+++ b/crates/unifly/src/tui/app/render.rs
@@ -145,7 +145,19 @@ impl App {
             " │ ? help  a about  / search  , settings  q quit",
             theme::key_hint(),
         );
-        let line = Line::from(vec![Span::raw(" "), connection_indicator, hints]);
+        let mut spans = vec![Span::raw(" "), connection_indicator];
+        if matches!(self.connection_status, ConnectionStatus::Disconnected)
+            && let Some(reason) = &self.connection_error
+        {
+            let max = usize::from(area.width).saturating_sub(60).max(24);
+            let short: String = reason.chars().take(max).collect();
+            spans.push(Span::styled(
+                format!(" ({short})"),
+                Style::default().fg(theme::error()),
+            ));
+        }
+        spans.push(hints);
+        let line = Line::from(spans);
 
         frame.render_widget(Paragraph::new(line), area);
 

--- a/crates/unifly/src/tui/mod.rs
+++ b/crates/unifly/src/tui/mod.rs
@@ -59,8 +59,8 @@ pub async fn launch(global: &GlobalOpts, args: TuiArgs) -> Result<()> {
         "starting unifly tui"
     );
 
-    let controller = build_controller_direct(global)
-        .or_else(|| build_controller_from_config(global.profile.as_deref()));
+    let controller =
+        build_controller_direct(global).or_else(|| build_controller_from_config(global));
 
     let sanitizer = resolve_sanitizer(global);
     let effects_enabled = resolve_effects_enabled(global);
@@ -127,7 +127,13 @@ fn build_controller_direct(global: &GlobalOpts) -> Option<Controller> {
             None
         }
     })?;
-    let url = url_str.parse().expect("invalid controller URL");
+    let url = match url_str.parse() {
+        Ok(url) => url,
+        Err(error) => {
+            tracing::warn!(%error, url = url_str, "invalid controller URL, ignoring direct flags");
+            return None;
+        }
+    };
 
     let api_key = SecretString::from(global.api_key.as_ref()?.clone());
 
@@ -137,7 +143,7 @@ fn build_controller_direct(global: &GlobalOpts) -> Option<Controller> {
             host_id: host_id.clone(),
         }
     } else {
-        try_hybrid_from_config(&api_key).unwrap_or(AuthCredentials::ApiKey(api_key))
+        try_hybrid_from_config(&api_key, global).unwrap_or(AuthCredentials::ApiKey(api_key))
     };
 
     let tls = if is_cloud {
@@ -172,9 +178,13 @@ fn build_controller_direct(global: &GlobalOpts) -> Option<Controller> {
     Some(Controller::new(controller_config))
 }
 
-fn try_hybrid_from_config(api_key: &SecretString) -> Option<AuthCredentials> {
+fn try_hybrid_from_config(api_key: &SecretString, global: &GlobalOpts) -> Option<AuthCredentials> {
     let cfg = config::load_config().ok()?;
-    let name = cfg.default_profile.as_deref().unwrap_or("default");
+    let name = global
+        .profile
+        .as_deref()
+        .or(cfg.default_profile.as_deref())
+        .unwrap_or("default");
     let profile = cfg.profiles.get(name)?;
 
     if profile.auth_mode != "hybrid" {
@@ -190,7 +200,7 @@ fn try_hybrid_from_config(api_key: &SecretString) -> Option<AuthCredentials> {
     })
 }
 
-fn build_controller_from_config(profile_name: Option<&str>) -> Option<Controller> {
+fn build_controller_from_config(global: &GlobalOpts) -> Option<Controller> {
     let cfg = match config::load_config() {
         Ok(cfg) => cfg,
         Err(e) => {
@@ -199,7 +209,9 @@ fn build_controller_from_config(profile_name: Option<&str>) -> Option<Controller
         }
     };
 
-    let profile_name = profile_name
+    let profile_name = global
+        .profile
+        .as_deref()
         .or(cfg.default_profile.as_deref())
         .unwrap_or("default");
 
@@ -211,8 +223,17 @@ fn build_controller_from_config(profile_name: Option<&str>) -> Option<Controller
         return None;
     };
 
-    match config::profile_to_controller_config(profile, profile_name) {
-        Ok(controller_config) => Some(Controller::new(controller_config)),
+    // The CLI resolver honors flag/env overrides (--insecure, --site,
+    // --api-key, --totp, --no-cache) that the plain profile translation
+    // does not; dropping them here is how issue #25 happened.
+    match config::resolve::resolve_profile(profile, profile_name, global) {
+        Ok(mut controller_config) => {
+            let is_cloud = matches!(controller_config.auth, AuthCredentials::Cloud { .. });
+            controller_config.refresh_interval_secs = if is_cloud { 60 } else { 10 };
+            controller_config.websocket_enabled = !is_cloud;
+            controller_config.polling_interval_secs = if is_cloud { 30 } else { 10 };
+            Some(Controller::new(controller_config))
+        }
         Err(e) => {
             tracing::warn!("failed to build controller from profile '{profile_name}': {e}");
             None

--- a/crates/unifly/src/tui/mod.rs
+++ b/crates/unifly/src/tui/mod.rs
@@ -166,7 +166,7 @@ fn build_controller_direct(global: &GlobalOpts) -> Option<Controller> {
         auth,
         site,
         tls,
-        timeout: std::time::Duration::from_secs(global.timeout),
+        timeout: std::time::Duration::from_secs(global.timeout_secs(None)),
         refresh_interval_secs: if is_cloud { 60 } else { 10 },
         websocket_enabled: !is_cloud,
         polling_interval_secs: if is_cloud { 30 } else { 10 },


### PR DESCRIPTION
## 🎯 What

Makes `unifly tui` honor the same flag and environment overrides as the CLI, surfaces connect failures instead of sitting on a bare "disconnected", and lets a profile's `timeout` field actually take effect.

Closes #25.

## 🔍 Why

The reporter's `UNIFI_INSECURE=true unifly tui -k -p default` showed "disconnected" forever while the identical CLI invocation worked. The TUI's profile fallback used `profile_to_controller_config`, which reads only profile values: every override the CLI honors (`--insecure`, `--site`, `--api-key`, `--totp`, `--no-cache`, `--controller`) was silently dropped. TLS verification then failed against the self-signed controller cert, and the failure was invisible because the data bridge discarded the error string before render.

## 🛠️ How

- The TUI profile path now resolves through `config::resolve::resolve_profile`, the same code path the CLI uses, then applies its own refresh/websocket/polling settings on the result (values unchanged from the old TUI behavior).
- Connect failures raise an error toast and render the truncated reason next to the disconnected indicator in the status bar.
- Two adjacent defects in the direct-flags path are fixed in the same sweep: an invalid `--controller` URL warns and falls through instead of panicking mid-launch, and hybrid credential lookup respects `--profile` instead of always reading the default profile.
- `GlobalOpts.timeout` becomes `Option<u64>` so an explicitly-passed flag is distinguishable from the default. Resolution follows the documented precedence: `--timeout`/`UNIFI_TIMEOUT` when given, then the profile's `timeout`, then 30. Previously the clap default made a profile's `timeout` field dead weight everywhere.

## 🧪 Testing

- A regression test asserts `--insecure` with an unset profile TLS field resolves to `DangerAcceptInvalid` through `resolve_profile`, the exact combination from the issue.
- All timeout consumers route through one `timeout_secs()` helper; the type change makes any straggler a compile error.
- `UNIFI_TIMEOUT` env parsing verified live through clap (`UNIFI_TIMEOUT=abc` fails with the expected invalid-digit error naming `--timeout`).
- `just check` passes: unifly 201 lib + 64 CLI tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
