### PR TITLE
feat(cli): print the created entity on stdout for every create

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Added
 
+- **Create commands print the created entity on stdout** in the requested
+  `--output` format (`-o plain` emits the new ID), so pipelines can
+  capture IDs directly: `unifly networks create ... -o json | jq -r .id`.
+  Covers networks, wifi, firewall policies/zones/groups, NAT, ACL, DNS,
+  traffic-lists, hotspot vouchers (codes included), and the VPN create
+  surface (session records, with private keys and PSKs redacted). The
+  human confirmation stays on stderr. `sites create` is unchanged: the
+  controller returns no record.
+
 - **Switch port management as code**: `devices ports`, `devices ports-export`,
   and `devices port-set` cover the full per-port surface (mode, native VLAN,
   tagged VLANs, PoE, speed). `port-set --from-file` accepts a JSONC payload

--- a/crates/unifly-api/src/command/mod.rs
+++ b/crates/unifly-api/src/command/mod.rs
@@ -8,8 +8,8 @@ pub mod requests;
 
 use crate::core_error::CoreError;
 use crate::model::{
-    AclRule, Client, Device, DnsPolicy, EntityId, FirewallPolicy, FirewallZone, MacAddress,
-    Network, TrafficMatchingList, Voucher, WifiBroadcast,
+    AclRule, Client, Device, DnsPolicy, EntityId, FirewallGroup, FirewallPolicy, FirewallZone,
+    MacAddress, NatPolicy, Network, TrafficMatchingList, Voucher, WifiBroadcast,
 };
 
 pub use requests::{
@@ -302,4 +302,8 @@ pub enum CommandResult {
     DnsPolicy(DnsPolicy),
     Vouchers(Vec<Voucher>),
     TrafficMatchingList(TrafficMatchingList),
+    FirewallGroup(FirewallGroup),
+    NatPolicy(NatPolicy),
+    /// Raw session-API record for entities without a domain model (VPN CRUD).
+    Json(serde_json::Value),
 }

--- a/crates/unifly-api/src/controller/commands/network.rs
+++ b/crates/unifly-api/src/controller/commands/network.rs
@@ -131,8 +131,8 @@ pub(super) async fn route(
                 dhcp_guarding: None,
                 extra,
             };
-            ic.create_network(&sid, &body).await?;
-            Ok(crate::command::CommandResult::Ok)
+            let created = ic.create_network(&sid, &body).await?;
+            Ok(crate::command::CommandResult::Network(created.into()))
         }
         Command::UpdateNetwork { id, update } => {
             let (ic, sid) = require_integration(integration, site_id, "UpdateNetwork")?;
@@ -184,8 +184,8 @@ pub(super) async fn route(
         Command::CreateWifiBroadcast(req) => {
             let (ic, sid) = require_integration(integration, site_id, "CreateWifiBroadcast")?;
             let body = build_create_wifi_broadcast_payload(&req);
-            ic.create_wifi_broadcast(&sid, &body).await?;
-            Ok(crate::command::CommandResult::Ok)
+            let created = ic.create_wifi_broadcast(&sid, &body).await?;
+            Ok(crate::command::CommandResult::WifiBroadcast(created.into()))
         }
         Command::UpdateWifiBroadcast { id, update } => {
             let (ic, sid) = require_integration(integration, site_id, "UpdateWifiBroadcast")?;

--- a/crates/unifly-api/src/controller/commands/policy/acl.rs
+++ b/crates/unifly-api/src/controller/commands/policy/acl.rs
@@ -37,8 +37,8 @@ pub(super) async fn route(ctx: &CommandContext, cmd: Command) -> Result<CommandR
                 )),
                 enforcing_device_filter: req.enforcing_device_filter,
             };
-            ic.create_acl_rule(&sid, &body).await?;
-            Ok(CommandResult::Ok)
+            let created = ic.create_acl_rule(&sid, &body).await?;
+            Ok(CommandResult::AclRule(created.into()))
         }
         Command::UpdateAclRule { id, update } => {
             let (ic, sid) = require_integration(integration, site_id, "UpdateAclRule")?;

--- a/crates/unifly-api/src/controller/commands/policy/dns.rs
+++ b/crates/unifly-api/src/controller/commands/policy/dns.rs
@@ -20,8 +20,9 @@ pub(super) async fn route(ctx: &CommandContext, cmd: Command) -> Result<CommandR
                 enabled: req.enabled,
                 fields,
             };
-            ic.create_dns_policy(&sid, &body).await?;
-            Ok(CommandResult::Ok)
+            let created = ic.create_dns_policy(&sid, &body).await?;
+            Ok(crate::convert::dns_policy_from_integration(created)
+                .map_or(CommandResult::Ok, CommandResult::DnsPolicy))
         }
         Command::UpdateDnsPolicy { id, update } => {
             let (ic, sid) = require_integration(integration, site_id, "UpdateDnsPolicy")?;

--- a/crates/unifly-api/src/controller/commands/policy/firewall.rs
+++ b/crates/unifly-api/src/controller/commands/policy/firewall.rs
@@ -44,6 +44,11 @@ pub(super) async fn route(ctx: &CommandContext, cmd: Command) -> Result<CommandR
                 connection_state_filter: req.connection_states,
             };
             let resp = ic.create_firewall_policy(&sid, &body).await?;
+            if resp.id.is_none() {
+                return Err(CoreError::ValidationFailed {
+                    message: "firewall policy create response did not include an id".into(),
+                });
+            }
             Ok(CommandResult::FirewallPolicy(resp.into()))
         }
         Command::UpdateFirewallPolicy { id, update } => {

--- a/crates/unifly-api/src/controller/commands/policy/firewall.rs
+++ b/crates/unifly-api/src/controller/commands/policy/firewall.rs
@@ -44,10 +44,7 @@ pub(super) async fn route(ctx: &CommandContext, cmd: Command) -> Result<CommandR
                 connection_state_filter: req.connection_states,
             };
             let resp = ic.create_firewall_policy(&sid, &body).await?;
-            let id = resp.id.ok_or_else(|| CoreError::ValidationFailed {
-                message: "firewall policy create response did not include an id".into(),
-            })?;
-            Ok(CommandResult::CreatedId(crate::model::EntityId::Uuid(id)))
+            Ok(CommandResult::FirewallPolicy(resp.into()))
         }
         Command::UpdateFirewallPolicy { id, update } => {
             let (ic, sid) = require_integration(integration, site_id, "UpdateFirewallPolicy")?;
@@ -211,8 +208,8 @@ pub(super) async fn route(ctx: &CommandContext, cmd: Command) -> Result<CommandR
                 name: req.name,
                 network_ids: network_uuids?,
             };
-            ic.create_firewall_zone(&sid, &body).await?;
-            Ok(CommandResult::Ok)
+            let created = ic.create_firewall_zone(&sid, &body).await?;
+            Ok(CommandResult::FirewallZone(created.into()))
         }
         Command::UpdateFirewallZone { id, update } => {
             let (ic, sid) = require_integration(integration, site_id, "UpdateFirewallZone")?;

--- a/crates/unifly-api/src/controller/commands/policy/firewall_groups.rs
+++ b/crates/unifly-api/src/controller/commands/policy/firewall_groups.rs
@@ -25,8 +25,11 @@ pub(super) async fn route(ctx: &CommandContext, cmd: Command) -> Result<CommandR
                 "group_members": req.group_members,
             });
 
-            session.create_firewall_group(&body).await?;
-            Ok(CommandResult::Ok)
+            let created = session.create_firewall_group(&body).await?;
+            Ok(created
+                .first()
+                .and_then(crate::convert::firewall_group_from_session)
+                .map_or(CommandResult::Ok, CommandResult::FirewallGroup))
         }
         Command::UpdateFirewallGroup { id, update } => {
             let session = require_session(session)?;

--- a/crates/unifly-api/src/controller/commands/policy/nat.rs
+++ b/crates/unifly-api/src/controller/commands/policy/nat.rs
@@ -84,8 +84,9 @@ pub(super) async fn route(ctx: &CommandContext, cmd: Command) -> Result<CommandR
             body["destination_filter"] =
                 build_filter(req.dst_address.as_deref(), req.dst_port.as_deref());
 
-            session.create_nat_rule(&body).await?;
-            Ok(CommandResult::Ok)
+            let created = session.create_nat_rule(&body).await?;
+            Ok(crate::convert::nat_policy_from_v2(&created)
+                .map_or(CommandResult::Ok, CommandResult::NatPolicy))
         }
         Command::UpdateNatPolicy { id, update } => {
             let session = require_session(session)?;

--- a/crates/unifly-api/src/controller/commands/policy/traffic_lists.rs
+++ b/crates/unifly-api/src/controller/commands/policy/traffic_lists.rs
@@ -28,8 +28,8 @@ pub(super) async fn route(ctx: &CommandContext, cmd: Command) -> Result<CommandR
                 list_type: req.list_type,
                 fields,
             };
-            ic.create_traffic_matching_list(&sid, &body).await?;
-            Ok(CommandResult::Ok)
+            let created = ic.create_traffic_matching_list(&sid, &body).await?;
+            Ok(CommandResult::TrafficMatchingList(created.into()))
         }
         Command::UpdateTrafficMatchingList { id, update } => {
             let (ic, sid) = require_integration(integration, site_id, "UpdateTrafficMatchingList")?;

--- a/crates/unifly-api/src/controller/commands/vpn.rs
+++ b/crates/unifly-api/src/controller/commands/vpn.rs
@@ -82,7 +82,12 @@ pub(super) async fn route(ctx: &CommandContext, cmd: Command) -> Result<CommandR
             let created = session
                 .create_wireguard_peers(require_legacy_id(&server_id)?, &body)
                 .await?;
-            Ok(created_record_result(&[created]))
+            // The batch endpoint answers with an array of created peers;
+            // unwrap it so the caller gets the peer record, not the envelope.
+            Ok(match created {
+                serde_json::Value::Array(items) => created_record_result(&items),
+                other => created_record_result(&[other]),
+            })
         }
         Command::UpdateWireGuardPeer {
             server_id,

--- a/crates/unifly-api/src/controller/commands/vpn.rs
+++ b/crates/unifly-api/src/controller/commands/vpn.rs
@@ -21,6 +21,15 @@ fn serialize_body<T: Serialize>(value: T, label: &str) -> Result<serde_json::Val
     })
 }
 
+/// Wrap the first created session record (secrets redacted) as a result.
+fn created_record_result(records: &[serde_json::Value]) -> CommandResult {
+    records.first().map_or(CommandResult::Ok, |record| {
+        CommandResult::Json(
+            crate::controller::session_queries::common::redact_sensitive_value(record),
+        )
+    })
+}
+
 pub(super) async fn route(ctx: &CommandContext, cmd: Command) -> Result<CommandResult, CoreError> {
     let session = ctx.session.as_ref();
 
@@ -28,8 +37,8 @@ pub(super) async fn route(ctx: &CommandContext, cmd: Command) -> Result<CommandR
         Command::CreateSiteToSiteVpn(req) => {
             let session = require_session(session)?;
             let body = serialize_body(req, "site-to-site VPN")?;
-            session.create_network_conf(&body).await?;
-            Ok(CommandResult::Ok)
+            let created = session.create_network_conf(&body).await?;
+            Ok(created_record_result(&created))
         }
         Command::UpdateSiteToSiteVpn { id, update } => {
             let session = require_session(session)?;
@@ -42,8 +51,8 @@ pub(super) async fn route(ctx: &CommandContext, cmd: Command) -> Result<CommandR
         Command::CreateRemoteAccessVpnServer(req) => {
             let session = require_session(session)?;
             let body = serialize_body(req, "remote-access VPN server")?;
-            session.create_network_conf(&body).await?;
-            Ok(CommandResult::Ok)
+            let created = session.create_network_conf(&body).await?;
+            Ok(created_record_result(&created))
         }
         Command::UpdateRemoteAccessVpnServer { id, update } => {
             let session = require_session(session)?;
@@ -56,8 +65,8 @@ pub(super) async fn route(ctx: &CommandContext, cmd: Command) -> Result<CommandR
         Command::CreateVpnClientProfile(req) => {
             let session = require_session(session)?;
             let body = serialize_body(req, "VPN client profile")?;
-            session.create_network_conf(&body).await?;
-            Ok(CommandResult::Ok)
+            let created = session.create_network_conf(&body).await?;
+            Ok(created_record_result(&created))
         }
         Command::UpdateVpnClientProfile { id, update } => {
             let session = require_session(session)?;
@@ -70,10 +79,10 @@ pub(super) async fn route(ctx: &CommandContext, cmd: Command) -> Result<CommandR
         Command::CreateWireGuardPeer { server_id, peer } => {
             let session = require_session(session)?;
             let body = serialize_body(vec![peer], "WireGuard peer")?;
-            session
+            let created = session
                 .create_wireguard_peers(require_legacy_id(&server_id)?, &body)
                 .await?;
-            Ok(CommandResult::Ok)
+            Ok(created_record_result(&[created]))
         }
         Command::UpdateWireGuardPeer {
             server_id,

--- a/crates/unifly-api/src/controller/session_queries.rs
+++ b/crates/unifly-api/src/controller/session_queries.rs
@@ -1,6 +1,6 @@
 mod admin;
 mod backups;
-mod common;
+pub(crate) mod common;
 mod raw;
 mod settings;
 mod stats;

--- a/crates/unifly-api/src/controller/session_queries/common.rs
+++ b/crates/unifly-api/src/controller/session_queries/common.rs
@@ -1,4 +1,4 @@
-pub(super) fn redact_sensitive_value(value: &serde_json::Value) -> serde_json::Value {
+pub(crate) fn redact_sensitive_value(value: &serde_json::Value) -> serde_json::Value {
     match value {
         serde_json::Value::Object(map) => serde_json::Value::Object(
             map.iter()

--- a/crates/unifly-api/tests/controller_runtime_test.rs
+++ b/crates/unifly-api/tests/controller_runtime_test.rs
@@ -439,6 +439,76 @@ async fn legacy_mode_rejects_integration_only_surfaces_clearly() {
 }
 
 #[tokio::test]
+async fn create_dns_policy_returns_created_entity() {
+    let server = MockServer::start().await;
+    mock_api_key_with_legacy(&server).await;
+
+    Mock::given(method("POST"))
+        .and(path(format!(
+            "/proxy/network/integration/v1/sites/{API_KEY_SITE_ID}/dns/policies"
+        )))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "type": "A_RECORD",
+            "id": "7bd0e8b1-0a44-4c15-93a1-4c0e8f5be7aa",
+            "enabled": true,
+            "metadata": {"origin": "USER_DEFINED"},
+            "domain": "printer.example.net",
+            "ipv4Address": "10.0.1.42",
+            "ttlSeconds": 300,
+        })))
+        .mount(&server)
+        .await;
+
+    let controller = Controller::new(base_config(
+        Url::parse(&server.uri()).unwrap(),
+        AuthCredentials::ApiKey(secret("the-key")),
+        LEGACY_SITE_NAME,
+        false,
+    ));
+    controller.connect().await.unwrap();
+
+    let result = controller
+        .execute(unifly_api::Command::CreateDnsPolicy(
+            unifly_api::CreateDnsPolicyRequest {
+                name: "printer.example.net".into(),
+                policy_type: DnsPolicyType::ARecord,
+                enabled: true,
+                domain: Some("printer.example.net".into()),
+                domains: None,
+                upstream: None,
+                value: Some("10.0.1.42".into()),
+                ttl_seconds: Some(300),
+                priority: None,
+                ipv4_address: None,
+                ipv6_address: None,
+                target_domain: None,
+                mail_server_domain: None,
+                text: None,
+                ip_address: None,
+                server_domain: None,
+                service: None,
+                protocol: None,
+                port: None,
+                weight: None,
+            },
+        ))
+        .await
+        .expect("create should succeed");
+
+    match result {
+        unifly_api::CommandResult::DnsPolicy(policy) => {
+            assert_eq!(policy.policy_type, DnsPolicyType::ARecord);
+            assert_eq!(policy.domain, "printer.example.net");
+            assert_eq!(policy.value, "10.0.1.42");
+            assert_eq!(policy.ttl_seconds, Some(300));
+        }
+        other => panic!("expected CommandResult::DnsPolicy, got {other:?}"),
+    }
+
+    controller.disconnect().await;
+}
+
+#[tokio::test]
 async fn api_key_mode_has_legacy_and_integration_access() {
     let server = MockServer::start().await;
     mock_api_key_with_legacy(&server).await;

--- a/crates/unifly/src/cli/commands/acl/handler.rs
+++ b/crates/unifly/src/cli/commands/acl/handler.rs
@@ -90,6 +90,8 @@ pub(super) async fn handle(
                     |r| r.id.to_string(),
                 );
                 crate::cli::output::print_output(&out, global.quiet);
+            } else {
+                crate::cli::output::warn_unrenderable_create(global.quiet);
             }
             if !global.quiet {
                 eprintln!("ACL rule created");

--- a/crates/unifly/src/cli/commands/acl/handler.rs
+++ b/crates/unifly/src/cli/commands/acl/handler.rs
@@ -80,7 +80,17 @@ pub(super) async fn handle(
                     destination_port,
                 )?
             };
-            controller.execute(CoreCommand::CreateAclRule(req)).await?;
+            let result = controller.execute(CoreCommand::CreateAclRule(req)).await?;
+            if let unifly_api::CommandResult::AclRule(rule) = result {
+                let rule = std::sync::Arc::new(rule);
+                let out = crate::cli::output::render_single(
+                    &global.output,
+                    &rule,
+                    super::render::detail,
+                    |r| r.id.to_string(),
+                );
+                crate::cli::output::print_output(&out, global.quiet);
+            }
             if !global.quiet {
                 eprintln!("ACL rule created");
             }

--- a/crates/unifly/src/cli/commands/dns.rs
+++ b/crates/unifly/src/cli/commands/dns.rs
@@ -160,6 +160,8 @@ pub async fn handle(
                 let out =
                     output::render_single(&global.output, &policy, detail, |d| d.id.to_string());
                 output::print_output(&out, global.quiet);
+            } else {
+                output::warn_unrenderable_create(global.quiet);
             }
             if !global.quiet {
                 eprintln!("DNS policy created");

--- a/crates/unifly/src/cli/commands/dns.rs
+++ b/crates/unifly/src/cli/commands/dns.rs
@@ -152,9 +152,15 @@ pub async fn handle(
                 }
             };
 
-            controller
+            let result = controller
                 .execute(CoreCommand::CreateDnsPolicy(req))
                 .await?;
+            if let unifly_api::CommandResult::DnsPolicy(policy) = result {
+                let policy = Arc::new(policy);
+                let out =
+                    output::render_single(&global.output, &policy, detail, |d| d.id.to_string());
+                output::print_output(&out, global.quiet);
+            }
             if !global.quiet {
                 eprintln!("DNS policy created");
             }

--- a/crates/unifly/src/cli/commands/firewall/groups.rs
+++ b/crates/unifly/src/cli/commands/firewall/groups.rs
@@ -186,6 +186,8 @@ async fn handle_create(
             g.id.to_string()
         });
         crate::cli::output::print_output(&out, global.quiet);
+    } else {
+        crate::cli::output::warn_unrenderable_create(global.quiet);
     }
     if !global.quiet {
         eprintln!("Firewall group created");

--- a/crates/unifly/src/cli/commands/firewall/groups.rs
+++ b/crates/unifly/src/cli/commands/firewall/groups.rs
@@ -177,9 +177,16 @@ async fn handle_create(
             group_members: members.unwrap_or_default(),
         }
     };
-    controller
+    let result = controller
         .execute(CoreCommand::CreateFirewallGroup(req))
         .await?;
+    if let unifly_api::CommandResult::FirewallGroup(group) = result {
+        let group = Arc::new(group);
+        let out = crate::cli::output::render_single(&global.output, &group, group_detail, |g| {
+            g.id.to_string()
+        });
+        crate::cli::output::print_output(&out, global.quiet);
+    }
     if !global.quiet {
         eprintln!("Firewall group created");
     }

--- a/crates/unifly/src/cli/commands/firewall/policies.rs
+++ b/crates/unifly/src/cli/commands/firewall/policies.rs
@@ -502,6 +502,8 @@ async fn handle_create(
             p.id.to_string()
         });
         crate::cli::output::print_output(&out, global.quiet);
+    } else {
+        crate::cli::output::warn_unrenderable_create(global.quiet);
     }
 
     report_create_outcome(

--- a/crates/unifly/src/cli/commands/firewall/policies.rs
+++ b/crates/unifly/src/cli/commands/firewall/policies.rs
@@ -482,24 +482,33 @@ async fn handle_create(
         .execute(CoreCommand::CreateFirewallPolicy(req))
         .await?;
 
-    let created_id = match &result {
-        unifly_api::CommandResult::CreatedId(id) => Some(id.to_string()),
+    let created = match result {
+        unifly_api::CommandResult::FirewallPolicy(policy) => Some(std::sync::Arc::new(policy)),
+        _ => None,
+    };
+    let created_id = created.as_ref().map(|policy| policy.id.clone());
+
+    let reorder_err = match (after_system, created_id.clone()) {
+        (true, Some(id)) => {
+            move_policy_after_system(controller, id, source_zone_id, destination_zone_id)
+                .await
+                .err()
+        }
         _ => None,
     };
 
-    let reorder_err = if after_system {
-        move_policy_after_system(controller, result, source_zone_id, destination_zone_id)
-            .await
-            .err()
-    } else {
-        None
-    };
+    if let Some(policy) = &created {
+        let out = crate::cli::output::render_single(&global.output, policy, policy_detail, |p| {
+            p.id.to_string()
+        });
+        crate::cli::output::print_output(&out, global.quiet);
+    }
 
     report_create_outcome(
         global,
         after_system,
         reorder_err.as_ref(),
-        created_id.as_deref(),
+        created_id.map(|id| id.to_string()).as_deref(),
     );
     Ok(())
 }
@@ -712,33 +721,31 @@ async fn handle_update(
 /// "After System Defined" in the zone-pair ordering.
 async fn move_policy_after_system(
     controller: &Controller,
-    result: unifly_api::CommandResult,
+    created_id: EntityId,
     source_zone_id: EntityId,
     destination_zone_id: EntityId,
 ) -> Result<(), CliError> {
-    if let unifly_api::CommandResult::CreatedId(created_id) = result {
-        let mut ordering = controller
-            .get_firewall_policy_ordering(&source_zone_id, &destination_zone_id)
-            .await?;
-        if let EntityId::Uuid(uuid) = &created_id {
-            ordering.before_system_defined.retain(|id| id != uuid);
-            ordering.after_system_defined.push(*uuid);
-        }
-        controller
-            .execute(CoreCommand::ReorderFirewallPolicies {
-                zone_pair: (source_zone_id, destination_zone_id),
-                before_system_ids: ordering
-                    .before_system_defined
-                    .into_iter()
-                    .map(EntityId::Uuid)
-                    .collect(),
-                after_system_ids: ordering
-                    .after_system_defined
-                    .into_iter()
-                    .map(EntityId::Uuid)
-                    .collect(),
-            })
-            .await?;
+    let mut ordering = controller
+        .get_firewall_policy_ordering(&source_zone_id, &destination_zone_id)
+        .await?;
+    if let EntityId::Uuid(uuid) = &created_id {
+        ordering.before_system_defined.retain(|id| id != uuid);
+        ordering.after_system_defined.push(*uuid);
     }
+    controller
+        .execute(CoreCommand::ReorderFirewallPolicies {
+            zone_pair: (source_zone_id, destination_zone_id),
+            before_system_ids: ordering
+                .before_system_defined
+                .into_iter()
+                .map(EntityId::Uuid)
+                .collect(),
+            after_system_ids: ordering
+                .after_system_defined
+                .into_iter()
+                .map(EntityId::Uuid)
+                .collect(),
+        })
+        .await?;
     Ok(())
 }

--- a/crates/unifly/src/cli/commands/firewall/zones.rs
+++ b/crates/unifly/src/cli/commands/firewall/zones.rs
@@ -118,6 +118,8 @@ pub(super) async fn handle(
                         z.id.to_string()
                     });
                 crate::cli::output::print_output(&out, global.quiet);
+            } else {
+                crate::cli::output::warn_unrenderable_create(global.quiet);
             }
             if !global.quiet {
                 eprintln!("Firewall zone created");

--- a/crates/unifly/src/cli/commands/firewall/zones.rs
+++ b/crates/unifly/src/cli/commands/firewall/zones.rs
@@ -108,9 +108,17 @@ pub(super) async fn handle(
                     network_ids,
                 }
             };
-            controller
+            let result = controller
                 .execute(CoreCommand::CreateFirewallZone(req))
                 .await?;
+            if let unifly_api::CommandResult::FirewallZone(zone) = result {
+                let zone = Arc::new(zone);
+                let out =
+                    crate::cli::output::render_single(&global.output, &zone, zone_detail, |z| {
+                        z.id.to_string()
+                    });
+                crate::cli::output::print_output(&out, global.quiet);
+            }
             if !global.quiet {
                 eprintln!("Firewall zone created");
             }

--- a/crates/unifly/src/cli/commands/hotspot.rs
+++ b/crates/unifly/src/cli/commands/hotspot.rs
@@ -144,6 +144,8 @@ pub async fn handle(
                     |v| v.id.to_string(),
                 );
                 output::print_output(&out, global.quiet);
+            } else {
+                output::warn_unrenderable_create(global.quiet);
             }
             if !global.quiet {
                 eprintln!("{count} voucher(s) created");

--- a/crates/unifly/src/cli/commands/hotspot.rs
+++ b/crates/unifly/src/cli/commands/hotspot.rs
@@ -134,7 +134,17 @@ pub async fn handle(
                 authorized_guest_limit: guest_limit,
             };
 
-            controller.execute(CoreCommand::CreateVouchers(req)).await?;
+            let result = controller.execute(CoreCommand::CreateVouchers(req)).await?;
+            if let unifly_api::CommandResult::Vouchers(vouchers) = result {
+                let vouchers: Vec<Arc<Voucher>> = vouchers.into_iter().map(Arc::new).collect();
+                let out = output::render_list(
+                    &global.output,
+                    &vouchers,
+                    |v| voucher_row(v, &p),
+                    |v| v.id.to_string(),
+                );
+                output::print_output(&out, global.quiet);
+            }
             if !global.quiet {
                 eprintln!("{count} voucher(s) created");
             }

--- a/crates/unifly/src/cli/commands/nat.rs
+++ b/crates/unifly/src/cli/commands/nat.rs
@@ -288,9 +288,14 @@ async fn handle_create(
         }
     };
 
-    controller
+    let result = controller
         .execute(CoreCommand::CreateNatPolicy(req))
         .await?;
+    if let unifly_api::CommandResult::NatPolicy(policy) = result {
+        let policy = Arc::new(policy);
+        let out = output::render_single(&global.output, &policy, nat_detail, |p| p.id.to_string());
+        output::print_output(&out, global.quiet);
+    }
     if !global.quiet {
         eprintln!("NAT policy created");
     }

--- a/crates/unifly/src/cli/commands/nat.rs
+++ b/crates/unifly/src/cli/commands/nat.rs
@@ -295,6 +295,8 @@ async fn handle_create(
         let policy = Arc::new(policy);
         let out = output::render_single(&global.output, &policy, nat_detail, |p| p.id.to_string());
         output::print_output(&out, global.quiet);
+    } else {
+        output::warn_unrenderable_create(global.quiet);
     }
     if !global.quiet {
         eprintln!("NAT policy created");

--- a/crates/unifly/src/cli/commands/networks.rs
+++ b/crates/unifly/src/cli/commands/networks.rs
@@ -181,6 +181,8 @@ pub async fn handle(
                 let out =
                     output::render_single(&global.output, &network, detail, |n| n.id.to_string());
                 output::print_output(&out, global.quiet);
+            } else {
+                output::warn_unrenderable_create(global.quiet);
             }
             if !global.quiet {
                 eprintln!("Network created");

--- a/crates/unifly/src/cli/commands/networks.rs
+++ b/crates/unifly/src/cli/commands/networks.rs
@@ -175,7 +175,13 @@ pub async fn handle(
                 }
             };
 
-            controller.execute(CoreCommand::CreateNetwork(req)).await?;
+            let result = controller.execute(CoreCommand::CreateNetwork(req)).await?;
+            if let unifly_api::CommandResult::Network(network) = result {
+                let network = Arc::new(network);
+                let out =
+                    output::render_single(&global.output, &network, detail, |n| n.id.to_string());
+                output::print_output(&out, global.quiet);
+            }
             if !global.quiet {
                 eprintln!("Network created");
             }

--- a/crates/unifly/src/cli/commands/traffic_lists.rs
+++ b/crates/unifly/src/cli/commands/traffic_lists.rs
@@ -134,6 +134,8 @@ pub async fn handle(
                 let out =
                     output::render_single(&global.output, &list, detail, |t| t.id.to_string());
                 output::print_output(&out, global.quiet);
+            } else {
+                output::warn_unrenderable_create(global.quiet);
             }
             if !global.quiet {
                 eprintln!("Traffic matching list created");

--- a/crates/unifly/src/cli/commands/traffic_lists.rs
+++ b/crates/unifly/src/cli/commands/traffic_lists.rs
@@ -126,9 +126,15 @@ pub async fn handle(
                     description: None,
                 }
             };
-            controller
+            let result = controller
                 .execute(CoreCommand::CreateTrafficMatchingList(req))
                 .await?;
+            if let unifly_api::CommandResult::TrafficMatchingList(list) = result {
+                let list = Arc::new(list);
+                let out =
+                    output::render_single(&global.output, &list, detail, |t| t.id.to_string());
+                output::print_output(&out, global.quiet);
+            }
             if !global.quiet {
                 eprintln!("Traffic matching list created");
             }

--- a/crates/unifly/src/cli/commands/vpn.rs
+++ b/crates/unifly/src/cli/commands/vpn.rs
@@ -232,9 +232,12 @@ async fn handle_site_to_site(
         }
         SiteToSiteVpnCommand::Create { from_file } => {
             let req = serde_json::from_value(util::read_json_file(&from_file)?)?;
-            controller
+            let result = controller
                 .execute(CoreCommand::CreateSiteToSiteVpn(req))
                 .await?;
+            if let unifly_api::CommandResult::Json(record) = result {
+                print_created_record(global, &record);
+            }
             if !global.quiet {
                 eprintln!("Site-to-site VPN created");
             }
@@ -265,6 +268,23 @@ async fn handle_site_to_site(
             Ok(())
         }
     }
+}
+
+/// Render a session record returned by a VPN create on stdout. Sensitive
+/// fields are already redacted at the library layer.
+fn print_created_record(global: &GlobalOpts, value: &serde_json::Value) {
+    let out = output::render_single(
+        &global.output,
+        value,
+        |v| serde_json::to_string_pretty(v).unwrap_or_default(),
+        |v| {
+            v.get("_id")
+                .and_then(serde_json::Value::as_str)
+                .unwrap_or_default()
+                .to_owned()
+        },
+    );
+    output::print_output(&out, global.quiet);
 }
 
 async fn handle_remote_access(
@@ -304,9 +324,12 @@ async fn handle_remote_access(
         }
         RemoteAccessVpnCommand::Create { from_file } => {
             let req = serde_json::from_value(util::read_json_file(&from_file)?)?;
-            controller
+            let result = controller
                 .execute(CoreCommand::CreateRemoteAccessVpnServer(req))
                 .await?;
+            if let unifly_api::CommandResult::Json(record) = result {
+                print_created_record(global, &record);
+            }
             if !global.quiet {
                 eprintln!("Remote-access VPN server created");
             }
@@ -460,9 +483,12 @@ async fn handle_clients(
         }
         VpnClientsCommand::Create { from_file } => {
             let req = serde_json::from_value(util::read_json_file(&from_file)?)?;
-            controller
+            let result = controller
                 .execute(CoreCommand::CreateVpnClientProfile(req))
                 .await?;
+            if let unifly_api::CommandResult::Json(record) = result {
+                print_created_record(global, &record);
+            }
             if !global.quiet {
                 eprintln!("VPN client created");
             }
@@ -583,12 +609,15 @@ async fn handle_peers(
             from_file,
         } => {
             let req = serde_json::from_value(util::read_json_file(&from_file)?)?;
-            controller
+            let result = controller
                 .execute(CoreCommand::CreateWireGuardPeer {
                     server_id: EntityId::Legacy(server_id),
                     peer: req,
                 })
                 .await?;
+            if let unifly_api::CommandResult::Json(record) = result {
+                print_created_record(global, &record);
+            }
             if !global.quiet {
                 eprintln!("WireGuard peer created");
             }

--- a/crates/unifly/src/cli/commands/vpn.rs
+++ b/crates/unifly/src/cli/commands/vpn.rs
@@ -237,6 +237,8 @@ async fn handle_site_to_site(
                 .await?;
             if let unifly_api::CommandResult::Json(record) = result {
                 print_created_record(global, &record);
+            } else {
+                output::warn_unrenderable_create(global.quiet);
             }
             if !global.quiet {
                 eprintln!("Site-to-site VPN created");
@@ -329,6 +331,8 @@ async fn handle_remote_access(
                 .await?;
             if let unifly_api::CommandResult::Json(record) = result {
                 print_created_record(global, &record);
+            } else {
+                output::warn_unrenderable_create(global.quiet);
             }
             if !global.quiet {
                 eprintln!("Remote-access VPN server created");
@@ -488,6 +492,8 @@ async fn handle_clients(
                 .await?;
             if let unifly_api::CommandResult::Json(record) = result {
                 print_created_record(global, &record);
+            } else {
+                output::warn_unrenderable_create(global.quiet);
             }
             if !global.quiet {
                 eprintln!("VPN client created");
@@ -617,6 +623,8 @@ async fn handle_peers(
                 .await?;
             if let unifly_api::CommandResult::Json(record) = result {
                 print_created_record(global, &record);
+            } else {
+                output::warn_unrenderable_create(global.quiet);
             }
             if !global.quiet {
                 eprintln!("WireGuard peer created");

--- a/crates/unifly/src/cli/commands/wifi.rs
+++ b/crates/unifly/src/cli/commands/wifi.rs
@@ -304,6 +304,8 @@ pub async fn handle(
                 let out =
                     output::render_single(&global.output, &wifi, detail, |w| w.id.to_string());
                 output::print_output(&out, global.quiet);
+            } else {
+                output::warn_unrenderable_create(global.quiet);
             }
             if !global.quiet {
                 eprintln!("WiFi broadcast created");

--- a/crates/unifly/src/cli/commands/wifi.rs
+++ b/crates/unifly/src/cli/commands/wifi.rs
@@ -296,9 +296,15 @@ pub async fn handle(
                 }
             };
 
-            controller
+            let result = controller
                 .execute(CoreCommand::CreateWifiBroadcast(req))
                 .await?;
+            if let unifly_api::CommandResult::WifiBroadcast(wifi) = result {
+                let wifi = Arc::new(wifi);
+                let out =
+                    output::render_single(&global.output, &wifi, detail, |w| w.id.to_string());
+                output::print_output(&out, global.quiet);
+            }
             if !global.quiet {
                 eprintln!("WiFi broadcast created");
             }

--- a/crates/unifly/src/cli/output.rs
+++ b/crates/unifly/src/cli/output.rs
@@ -240,6 +240,17 @@ where
     }
 }
 
+/// Warn when a create succeeded on the controller but its response could
+/// not be converted for rendering, so stdout stays empty. The mutation is
+/// real; failing the command here would invite duplicate-create retries.
+pub fn warn_unrenderable_create(quiet: bool) {
+    if !quiet {
+        eprintln!(
+            "Warning: created, but the controller response could not be rendered; use the matching list command to fetch the new entity"
+        );
+    }
+}
+
 /// Print the rendered output to stdout, respecting quiet mode.
 pub fn print_output(output: &str, quiet: bool) {
     if quiet || output.is_empty() {

--- a/skills/unifly/references/commands.md
+++ b/skills/unifly/references/commands.md
@@ -766,6 +766,12 @@ silent truncation.**
   downstream command takes that same ID
 - `-o table`: Human display only, not for parsing
 
+Create commands print the created entity on stdout in the requested
+format (`-o plain` emits the new ID), plus a human confirmation on
+stderr. `sites create` is the exception: the controller returns no
+record. VPN create output has sensitive fields (private keys, PSKs)
+redacted, same as `get`.
+
 Mind the identifier type: `clients list -o plain` emits client UUIDs,
 but `clients block` takes a MAC. Extract the right field with `jq`
 instead:

--- a/skills/unifly/references/workflows.md
+++ b/skills/unifly/references/workflows.md
@@ -50,23 +50,20 @@ Network, firewall zone, WiFi SSID, and an isolation policy in one script:
 #!/usr/bin/env bash
 set -euo pipefail
 
-# 1. Create the network, then fetch its ID by name.
-#    (create commands confirm on stderr and print nothing to stdout,
-#    so IDs are captured with a follow-up list + jq filter)
-unifly networks create \
+# 1. Create the network. Create commands print the created entity on
+#    stdout in the requested format, so the ID captures directly.
+NETWORK_ID=$(unifly networks create \
   --name "IoT" \
   --vlan 30 \
   --management gateway \
   --ipv4-host 10.0.30.1/24 \
   --dhcp --dhcp-start 10.0.30.100 --dhcp-stop 10.0.30.254 \
-  --dns 1.1.1.1 --dns 1.0.0.1
-NETWORK_ID=$(unifly networks list --all -o json | \
-  jq -r '.[] | select(.name == "IoT") | .id')
+  --dns 1.1.1.1 --dns 1.0.0.1 \
+  -o json | jq -r '.id')
 
 # 2. Create a firewall zone that owns it
-unifly firewall zones create --name "IoT Zone" --networks "$NETWORK_ID"
-ZONE_ID=$(unifly firewall zones list --all -o json | \
-  jq -r '.[] | select(.name == "IoT Zone") | .id')
+ZONE_ID=$(unifly firewall zones create \
+  --name "IoT Zone" --networks "$NETWORK_ID" -o json | jq -r '.id')
 
 # 3. Grab the Internal zone ID (default LAN zone)
 INTERNAL_ZONE_ID=$(unifly firewall zones list -o json | \
@@ -272,16 +269,13 @@ Generate vouchers, export as a printable list with QR codes.
 set -euo pipefail
 
 BATCH="Cafe-$(date +%Y-%m-%d)"
-unifly hotspot create \
+# hotspot create prints the generated vouchers (codes included) on stdout
+VOUCHERS=$(unifly hotspot create \
   --name "$BATCH" \
   --count 20 \
   --minutes 1440 \
-  --rx-limit-kbps 20000 --tx-limit-kbps 5000
-
-# create prints confirmation on stderr only; fetch the batch by name
-# (hotspot list has no --all; it takes --limit up to 1000)
-VOUCHERS=$(unifly hotspot list --limit 1000 -o json | \
-  jq --arg name "$BATCH" '[.[] | select(.name == $name)]')
+  --rx-limit-kbps 20000 --tx-limit-kbps 5000 \
+  -o json)
 
 # Extract codes
 echo "$VOUCHERS" | jq -r '.[].code' > vouchers.txt
@@ -594,9 +588,10 @@ unifly --no-cache devices list
 
 1. **Inspect before mutating.** Always `get` or `list` an entity before
    `create`, `update`, or `delete`.
-2. **Capture IDs with a list after create.** Create commands confirm on
-   stderr and print nothing to stdout, so follow up with
-   `unifly ... list --all -o json | jq -r '.[] | select(.name == "X") | .id'`.
+2. **Capture IDs from create output.** Create commands print the created
+   entity on stdout: `unifly ... create -o json | jq -r '.id'`, or
+   `-o plain` for the bare ID. (Exception: `sites create` returns no
+   record from the controller.)
 3. **Verify after changes.** Re-fetch to confirm state.
 4. **Stagger bulk device operations.** Add `sleep` between restarts,
    upgrades, and port cycles to avoid overwhelming the controller.


### PR DESCRIPTION
## 🎯 What

Every create command now prints the created entity on stdout in the requested `--output` format, so pipelines capture IDs directly: `unifly networks create ... -o json | jq -r '.id'`, or `-o plain` for the bare ID.

## 🔍 Why

Creates confirmed on stderr and emitted nothing on stdout, which made created IDs uncapturable in scripts; the agent skill worked around it with create-then-list-by-name. The controller APIs return the created object on every create, and the command layer was discarding it one call below the handler. This is the biggest agent-UX gap on the board and an output-contract change that belongs in the 0.10.0 minor bump.

## 🛠️ How

- Command implementations convert the API response and return it through the `CommandResult` entity variants; the enum gains `FirewallGroup`, `NatPolicy`, and `Json` (raw session record) variants for the session-backed surfaces.
- Handlers render through the same `render_single` path `get` uses: json/yaml serialize the record, table shows the detail view, plain emits the bare ID. The human confirmation stays on stderr.
- Hotspot vouchers render as the standard list with codes visible, which is what the cafe voucher workflow needed all along.
- VPN create responses pass through the session-query secret redaction before rendering, so generated private keys and PSKs stay out of stdout exactly as they do in `get`.
- `sites create` is unchanged: the controller returns no record for it, and the docs say so.
- The firewall `--after-system` flow reads the created ID from the returned policy, replacing the `CreatedId` plumbing it used before.
- Skill recipes drop the create-then-list workaround for direct capture, and the changelog documents the new contract.

## 🧪 Testing

- A wiremock runtime test mounts a POST route and asserts `execute(CreateDnsPolicy)` returns `CommandResult::DnsPolicy` carrying the created record's type, value, and TTL.
- Full workspace gate green: `cargo clippy --locked --workspace -- -D warnings` clean, all 11 test suites pass.
- The e2e branch (separate PR) exercises live creates for firewall groups and NAT against the docker controller; its assertions are written to hold under both the old and new stdout contract.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Create commands now display newly created resources in the requested output format, including networks, Wi-Fi broadcasts, policies, firewall resources, traffic lists, hotspots, and VPN configurations.
  * VPN output automatically redacts private keys, PSKs, and other sensitive values.
  * Creation confirmations remain separate from structured output, enabling reliable ID and data capture.

* **Documentation**
  * Updated command references and automation examples to reflect the new output behavior.
  * Documented the exception that `sites create` returns no resource record.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->