### PR TITLE
feat(tui): auto-reconnect with backoff and a manual retry key

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
   human confirmation stays on stderr. `sites create` is unchanged: the
   controller returns no record.
 
+- **TUI auto-reconnect**: a failed controller connection no longer leaves
+  the dashboard dead. The data bridge retries with exponential backoff
+  (2s doubling to a 30s cap, indefinitely), the status bar shows the
+  attempt number while reconnecting, and `Ctrl+r` triggers an immediate
+  manual retry when disconnected.
 - **Switch port management as code**: `devices ports`, `devices ports-export`,
   and `devices port-set` cover the full per-port surface (mode, native VLAN,
   tagged VLANs, PoE, speed). `port-set --from-file` accepts a JSONC payload

--- a/crates/unifly/src/tui/action.rs
+++ b/crates/unifly/src/tui/action.rs
@@ -348,7 +348,10 @@ pub enum Action {
     // ── Connection Status ─────────────────────────────────────────
     Connected,
     Disconnected(String),
-    Reconnecting,
+    Reconnecting {
+        attempt: u32,
+    },
+    RetryConnect,
 
     // ── Device Selection ──────────────────────────────────────────
     SelectDevice(usize),

--- a/crates/unifly/src/tui/app.rs
+++ b/crates/unifly/src/tui/app.rs
@@ -37,7 +37,9 @@ pub enum ConnectionStatus {
     Disconnected,
     Connecting,
     Connected,
-    Reconnecting,
+    Reconnecting {
+        attempt: u32,
+    },
 }
 
 /// Top-level application state and event loop.

--- a/crates/unifly/src/tui/app.rs
+++ b/crates/unifly/src/tui/app.rs
@@ -77,6 +77,9 @@ pub struct App {
     sanitizer: Option<Arc<Sanitizer>>,
     /// Cancellation token for the data bridge task.
     data_cancel: CancellationToken,
+    /// Handle of the newest data bridge task — successors chain on it so
+    /// bridge lifetimes never overlap on the same controller.
+    bridge_handle: Option<tokio::task::JoinHandle<()>>,
     /// Pending confirmation dialog (blocks other input while active).
     pending_confirm: Option<ConfirmAction>,
     /// Active notification toast with display timestamp.
@@ -144,6 +147,7 @@ impl App {
             controller,
             sanitizer,
             data_cancel: CancellationToken::new(),
+            bridge_handle: None,
             pending_confirm: None,
             notification: None,
             stats_generation: std::sync::Arc::new(std::sync::atomic::AtomicU64::new(0)),
@@ -184,12 +188,7 @@ impl App {
         self.init_screens()?;
 
         if let Some(controller) = self.controller.clone() {
-            let cancel = self.data_cancel.clone();
-            let tx = self.action_tx.clone();
-            let sanitizer = self.sanitizer.clone();
-            tokio::spawn(async move {
-                crate::tui::data_bridge::spawn_data_bridge(controller, tx, cancel, sanitizer).await;
-            });
+            self.spawn_data_bridge(controller);
         }
 
         // Reset the frame clock so the first draw gets a sane delta, then

--- a/crates/unifly/src/tui/app/dispatch.rs
+++ b/crates/unifly/src/tui/app/dispatch.rs
@@ -59,13 +59,20 @@ impl App {
             }
             Action::Disconnected(reason) => {
                 self.connection_status = ConnectionStatus::Disconnected;
-                self.show_notification(crate::tui::action::Notification::error(format!(
-                    "connection failed: {reason}"
-                )));
+                // Auto-reconnect resends this action after every failed
+                // attempt; only toast when the failure reason is news.
+                if self.connection_error.as_ref() != Some(reason) {
+                    self.show_notification(crate::tui::action::Notification::error(format!(
+                        "connection failed: {reason}"
+                    )));
+                }
                 self.connection_error = Some(reason.clone());
             }
-            Action::Reconnecting => {
-                self.connection_status = ConnectionStatus::Reconnecting;
+            Action::Reconnecting { attempt } => {
+                self.connection_status = ConnectionStatus::Reconnecting { attempt: *attempt };
+            }
+            Action::RetryConnect => {
+                self.retry_connect();
             }
             Action::Invalidate => {
                 self.needs_redraw = true;

--- a/crates/unifly/src/tui/app/lifecycle.rs
+++ b/crates/unifly/src/tui/app/lifecycle.rs
@@ -63,13 +63,20 @@ impl App {
         Ok(())
     }
 
-    fn spawn_data_bridge(&self, controller: Controller) {
+    pub(super) fn spawn_data_bridge(&mut self, controller: Controller) {
         let cancel = self.data_cancel.clone();
         let tx = self.action_tx.clone();
         let sanitizer = self.sanitizer.clone();
-        tokio::spawn(async move {
+        // Chain on the previous bridge so its teardown (including the
+        // mid-connect disconnect cleanup) fully completes before the next
+        // bridge touches shared controller state.
+        let predecessor = self.bridge_handle.take();
+        self.bridge_handle = Some(tokio::spawn(async move {
+            if let Some(previous) = predecessor {
+                let _ = previous.await;
+            }
             crate::tui::data_bridge::spawn_data_bridge(controller, tx, cancel, sanitizer).await;
-        });
+        }));
     }
 
     fn reset_data_bridge(&mut self) {

--- a/crates/unifly/src/tui/app/lifecycle.rs
+++ b/crates/unifly/src/tui/app/lifecycle.rs
@@ -76,6 +76,20 @@ impl App {
         self.data_cancel.cancel();
         self.data_cancel = CancellationToken::new();
     }
+
+    /// Immediately retry connecting after a failure, replacing the old
+    /// data bridge (and its pending backoff sleep) with a fresh one.
+    pub(super) fn retry_connect(&mut self) {
+        if self.connection_status != super::ConnectionStatus::Disconnected {
+            return;
+        }
+        let Some(controller) = self.controller.clone() else {
+            return;
+        };
+
+        self.reset_data_bridge();
+        self.spawn_data_bridge(controller);
+    }
 }
 
 #[cfg(test)]

--- a/crates/unifly/src/tui/app/navigation.rs
+++ b/crates/unifly/src/tui/app/navigation.rs
@@ -1,7 +1,7 @@
 use color_eyre::eyre::Result;
 use crossterm::event::{KeyCode, KeyEvent, KeyModifiers, MouseButton, MouseEvent, MouseEventKind};
 
-use super::App;
+use super::{App, ConnectionStatus};
 use crate::tui::action::Action;
 use crate::tui::screen::ScreenId;
 
@@ -48,6 +48,15 @@ impl App {
                 }
                 _ => None,
             });
+        }
+
+        // Intercepted ahead of screen forwarding: screen key handlers match
+        // on the bare key code and would swallow Ctrl+r as a plain 'r'.
+        if key.modifiers == KeyModifiers::CONTROL
+            && key.code == KeyCode::Char('r')
+            && self.connection_status == ConnectionStatus::Disconnected
+        {
+            return Ok(Some(Action::RetryConnect));
         }
 
         if let Ok(Some(action)) = self.forward_key_to_active_screen(key) {

--- a/crates/unifly/src/tui/app/render.rs
+++ b/crates/unifly/src/tui/app/render.rs
@@ -133,18 +133,30 @@ impl App {
             ConnectionStatus::Disconnected => {
                 Span::styled("○ disconnected", Style::default().fg(theme::error()))
             }
-            ConnectionStatus::Reconnecting => {
-                Span::styled("◐ reconnecting", Style::default().fg(theme::warning()))
+            ConnectionStatus::Reconnecting { attempt } => {
+                let label = if attempt > 1 {
+                    format!("◐ reconnecting (attempt {attempt})")
+                } else {
+                    "◐ reconnecting".to_string()
+                };
+                Span::styled(label, Style::default().fg(theme::warning()))
             }
             ConnectionStatus::Connecting => {
                 Span::styled("◐ connecting", Style::default().fg(theme::warning()))
             }
         };
 
-        let hints = Span::styled(
-            " │ ? help  a about  / search  , settings  q quit",
-            theme::key_hint(),
-        );
+        let hints = if self.connection_status == ConnectionStatus::Disconnected {
+            Span::styled(
+                " │ ^r retry  ? help  a about  / search  , settings  q quit",
+                theme::key_hint(),
+            )
+        } else {
+            Span::styled(
+                " │ ? help  a about  / search  , settings  q quit",
+                theme::key_hint(),
+            )
+        };
         let mut spans = vec![Span::raw(" "), connection_indicator];
         if matches!(self.connection_status, ConnectionStatus::Disconnected)
             && let Some(reason) = &self.connection_error
@@ -370,7 +382,9 @@ impl App {
             ]),
             Line::from(vec![
                 Span::styled("  q           ", theme::key_hint_key()),
-                Span::styled("Quit", theme::key_hint()),
+                Span::styled("Quit               ", theme::key_hint()),
+                Span::styled("^r ", theme::key_hint_key()),
+                Span::styled("Retry connect", theme::key_hint()),
             ]),
             Line::from(""),
             Line::from(Span::styled(

--- a/crates/unifly/src/tui/data_bridge.rs
+++ b/crates/unifly/src/tui/data_bridge.rs
@@ -5,6 +5,7 @@
 //! through the TUI's action channel.
 
 use std::sync::Arc;
+use std::time::Duration;
 
 use tokio::sync::mpsc;
 use tokio_util::sync::CancellationToken;
@@ -15,9 +16,19 @@ use unifly_api::{ConnectionState, Controller, Event};
 use crate::sanitizer::Sanitizer;
 use crate::tui::action::Action;
 
+/// Delay before connect attempt `attempt + 1`: exponential from 2s,
+/// doubling each attempt, capped at 30s.
+fn connect_backoff(attempt: u32) -> Duration {
+    const BASE_SECS: u64 = 2;
+    const MAX_SECS: u64 = 30;
+    let exponent = attempt.saturating_sub(1).min(6);
+    Duration::from_secs((BASE_SECS << exponent).min(MAX_SECS))
+}
+
 /// Spawn the data bridge connecting [`Controller`] reactive streams to the TUI.
 ///
-/// Connects to the controller, sends initial data snapshots, then loops
+/// Connects to the controller (retrying failed attempts with bounded
+/// exponential backoff), sends initial data snapshots, then loops
 /// forwarding every entity change and connection-state transition as an
 /// [`Action`]. Shuts down cleanly on cancellation.
 ///
@@ -30,13 +41,27 @@ pub async fn spawn_data_bridge(
     cancel: CancellationToken,
     sanitizer: Option<Arc<Sanitizer>>,
 ) {
-    // Signal connecting state
-    let _ = action_tx.send(Action::Reconnecting);
+    let mut attempt: u32 = 1;
+    loop {
+        let _ = action_tx.send(Action::Reconnecting { attempt });
 
-    if let Err(e) = controller.connect().await {
-        warn!(error = %e, "failed to connect to controller");
-        let _ = action_tx.send(Action::Disconnected(format!("{e}")));
-        return;
+        match controller.connect().await {
+            Ok(()) => break,
+            Err(e) => {
+                warn!(error = %e, attempt, "failed to connect to controller");
+                let _ = action_tx.send(Action::Disconnected(format!("{e}")));
+
+                tokio::select! {
+                    () = cancel.cancelled() => {
+                        debug!("data bridge cancelled while waiting to reconnect");
+                        return;
+                    }
+                    () = tokio::time::sleep(connect_backoff(attempt)) => {}
+                }
+
+                attempt = attempt.saturating_add(1);
+            }
+        }
     }
 
     let _ = action_tx.send(Action::Connected);
@@ -190,8 +215,8 @@ pub async fn spawn_data_bridge(
                     ConnectionState::Disconnected => {
                         let _ = action_tx.send(Action::Disconnected("disconnected".into()));
                     }
-                    ConnectionState::Reconnecting { .. } => {
-                        let _ = action_tx.send(Action::Reconnecting);
+                    ConnectionState::Reconnecting { attempt } => {
+                        let _ = action_tx.send(Action::Reconnecting { attempt });
                     }
                     ConnectionState::Failed => {
                         let _ = action_tx.send(Action::Disconnected("connection failed".into()));
@@ -204,4 +229,24 @@ pub async fn spawn_data_bridge(
 
     controller.disconnect().await;
     debug!("data bridge shut down");
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn connect_backoff_doubles_from_two_seconds() {
+        assert_eq!(connect_backoff(1), Duration::from_secs(2));
+        assert_eq!(connect_backoff(2), Duration::from_secs(4));
+        assert_eq!(connect_backoff(3), Duration::from_secs(8));
+        assert_eq!(connect_backoff(4), Duration::from_secs(16));
+    }
+
+    #[test]
+    fn connect_backoff_caps_at_thirty_seconds() {
+        assert_eq!(connect_backoff(5), Duration::from_secs(30));
+        assert_eq!(connect_backoff(6), Duration::from_secs(30));
+        assert_eq!(connect_backoff(u32::MAX), Duration::from_secs(30));
+    }
 }

--- a/crates/unifly/src/tui/data_bridge.rs
+++ b/crates/unifly/src/tui/data_bridge.rs
@@ -43,9 +43,28 @@ pub async fn spawn_data_bridge(
 ) {
     let mut attempt: u32 = 1;
     loop {
+        if cancel.is_cancelled() {
+            debug!("data bridge cancelled before connect attempt");
+            return;
+        }
+
         let _ = action_tx.send(Action::Reconnecting { attempt });
 
-        match controller.connect().await {
+        let connect_result = tokio::select! {
+            biased;
+            () = cancel.cancelled() => {
+                // The dropped connect may have installed clients or even
+                // spawned background tasks under the controller's current
+                // child token; disconnect reaps them so a successor bridge
+                // starts from a clean controller.
+                debug!("data bridge cancelled mid-connect; cleaning up");
+                controller.disconnect().await;
+                return;
+            }
+            result = controller.connect() => result,
+        };
+
+        match connect_result {
             Ok(()) => break,
             Err(e) => {
                 warn!(error = %e, attempt, "failed to connect to controller");
@@ -248,5 +267,36 @@ mod tests {
         assert_eq!(connect_backoff(5), Duration::from_secs(30));
         assert_eq!(connect_backoff(6), Duration::from_secs(30));
         assert_eq!(connect_backoff(u32::MAX), Duration::from_secs(30));
+    }
+
+    #[tokio::test]
+    async fn bridge_exits_before_connecting_when_already_cancelled() {
+        // Loopback port 1 so a regression fails on a refused local connect
+        // instead of reaching a plausible real controller address. The
+        // passing path performs no I/O at all: the guard returns first.
+        let config = unifly_api::ControllerConfig {
+            url: "https://127.0.0.1:1"
+                .parse()
+                .expect("loopback URL is valid"),
+            websocket_enabled: false,
+            refresh_interval_secs: 0,
+            ..unifly_api::ControllerConfig::default()
+        };
+        let controller = Controller::new(config);
+        let (tx, mut rx) = mpsc::unbounded_channel();
+        let cancel = CancellationToken::new();
+        cancel.cancel();
+
+        tokio::time::timeout(
+            Duration::from_secs(10),
+            spawn_data_bridge(controller, tx, cancel, None),
+        )
+        .await
+        .expect("cancelled bridge should exit immediately");
+
+        assert!(
+            rx.try_recv().is_err(),
+            "cancelled bridge must not emit actions or attempt a connect"
+        );
     }
 }


### PR DESCRIPTION
## 🎯 What

The TUI reconnects automatically with bounded backoff after a failed connect, and Ctrl+r retries immediately while disconnected. Completes the story issue #25 started: the failure reason became visible in the status bar, and now the TUI acts on it instead of sitting dead.

## 🔍 Why

A failed first connect killed the data-bridge task permanently: the TUI stayed "disconnected" until restart even after the underlying problem (controller rebooting, transient network) cleared.

## 🛠️ How

- The one-shot connect in `data_bridge.rs` is now a retry loop: each attempt sends `Reconnecting { attempt }`, each failure sends `Disconnected(reason)` and sleeps a pure-function backoff (2s, 4s, 8s, 16s, then 30s capped). The sleep sits in a `tokio::select!` against the cancellation token, so quit and settings-apply tear down promptly.
- Ctrl+r dispatches `RetryConnect`, which gates on Disconnected and reuses the exact `reset_data_bridge` + respawn path `apply_settings` already uses. Plain `r` was taken three times over (stats refresh, topology reset, wifi roaming), and screen key handlers match on `key.code` ignoring modifiers, so the binding is intercepted before screen forwarding and only while disconnected — screens keep their `r` bindings when connected.
- The status bar shows `◐ reconnecting (attempt N)` from attempt 2 onward and a `^r retry` hint while disconnected; the help overlay documents the key.
- Repeated failures with an unchanged reason no longer re-pop the error toast every cycle; a changed reason still toasts.

## 🧪 Testing

- The backoff curve is a pure function with unit tests covering the doubling sequence, the 30s cap, and `u32::MAX`.
- `cargo clippy --locked --workspace --all-targets -- -D warnings` clean; `cargo test -p unifly --all-features --lib` → 203 passed.
- Not verified live against a controller (out of scope for the implementation environment); runtime behavior is covered by the pure-function tests plus existing lifecycle and render tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
