### PR TITLE
fix(config): init offers insecure TLS and [defaults] fields take effect

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -136,6 +136,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Fixed
 
+- The `[defaults]` config fields `insecure` and `timeout` are now honored
+  during profile resolution instead of being parsed and ignored. Precedence
+  is CLI flags > env vars > profile > `[defaults]` > builtin.
+- `config init` now asks whether the controller uses a self-signed
+  certificate (defaulting yes for IPs, `.local`/`.lan`-style hosts, and
+  single-label hostnames) and writes `insecure = true` into the profile,
+  so the canonical UDM/UCG setup no longer produces a profile that fails
+  TLS everywhere `-k` isn't passed.
 - Port range items in firewall policy payloads now serialize as
   `PORT_NUMBER_RANGE` instead of `PORT_RANGE`, which the UDM API rejects.
   `PORT_RANGE` is still accepted on read for backward compatibility.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -138,7 +138,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 - The `[defaults]` config fields `insecure` and `timeout` are now honored
   during profile resolution instead of being parsed and ignored. Precedence
-  is CLI flags > env vars > profile > `[defaults]` > builtin.
+  is CLI flags > env vars > profile > `[defaults]` > builtin. A profile's
+  `ca_cert` beats an inherited `[defaults]` `insecure = true`, and
+  `--insecure=false` / `UNIFI_INSECURE=false` explicitly re-enables
+  verification over any profile or defaults setting (bare `--insecure`
+  still means true).
 - `config init` now asks whether the controller uses a self-signed
   certificate (defaulting yes for IPs, `.local`/`.lan`-style hosts, and
   single-label hostnames) and writes `insecure = true` into the profile,

--- a/crates/unifly/src/bin/cli.rs
+++ b/crates/unifly/src/bin/cli.rs
@@ -133,10 +133,15 @@ async fn build_controller_config(
             let mut resolved_profile = profile.clone();
             resolved_profile.host_id = Some(commands::cloud::auto_resolve_host_id(global).await?);
             resolved_profile.host_id_env = None;
-            return resolve::resolve_profile(&resolved_profile, &profile_name, global);
+            return resolve::resolve_profile(
+                &resolved_profile,
+                &profile_name,
+                global,
+                &cfg.defaults,
+            );
         }
 
-        return resolve::resolve_profile(profile, &profile_name, global);
+        return resolve::resolve_profile(profile, &profile_name, global, &cfg.defaults);
     }
 
     let is_cloud =
@@ -195,7 +200,9 @@ async fn build_controller_config(
         auth,
         site: global.site.clone().unwrap_or_else(|| "default".into()),
         tls,
-        timeout: std::time::Duration::from_secs(global.timeout_secs(None)),
+        timeout: std::time::Duration::from_secs(
+            global.timeout_secs(None, Some(cfg.defaults.timeout)),
+        ),
         refresh_interval_secs: 0,
         websocket_enabled: false,
         polling_interval_secs: 30,

--- a/crates/unifly/src/bin/cli.rs
+++ b/crates/unifly/src/bin/cli.rs
@@ -184,7 +184,7 @@ async fn build_controller_config(
 
     let tls = if is_cloud {
         unifly_api::TlsVerification::SystemDefaults
-    } else if global.insecure {
+    } else if global.insecure.unwrap_or(cfg.defaults.insecure) {
         unifly_api::TlsVerification::DangerAcceptInvalid
     } else {
         unifly_api::TlsVerification::SystemDefaults

--- a/crates/unifly/src/cli/args/common.rs
+++ b/crates/unifly/src/cli/args/common.rs
@@ -66,9 +66,18 @@ pub struct GlobalOpts {
     #[arg(long, env = "UNIFI_DEMO", global = true)]
     pub demo: bool,
 
-    /// Accept self-signed TLS certificates
-    #[arg(long, short = 'k', env = "UNIFI_INSECURE", global = true)]
-    pub insecure: bool,
+    /// Accept self-signed TLS certificates (--insecure=false forces verification)
+    #[arg(
+        long,
+        short = 'k',
+        env = "UNIFI_INSECURE",
+        global = true,
+        num_args = 0..=1,
+        default_missing_value = "true",
+        require_equals = true,
+        value_name = "BOOL"
+    )]
+    pub insecure: Option<bool>,
 
     /// Request timeout in seconds (default 30, profiles may override)
     #[arg(long, env = "UNIFI_TIMEOUT", global = true)]

--- a/crates/unifly/src/cli/commands/cloud.rs
+++ b/crates/unifly/src/cli/commands/cloud.rs
@@ -16,7 +16,7 @@ use unifly_api::{
 
 use crate::cli::args::{CloudArgs, CloudCommand, GlobalOpts};
 use crate::cli::error::CliError;
-use crate::config::{self, Profile};
+use crate::config::{self, Defaults, Profile};
 
 pub async fn handle(args: CloudArgs, global: &GlobalOpts) -> Result<(), CliError> {
     match args.command {
@@ -38,11 +38,15 @@ pub async fn handle(args: CloudArgs, global: &GlobalOpts) -> Result<(), CliError
 pub(crate) fn build_site_manager_client(
     global: &GlobalOpts,
 ) -> Result<SiteManagerClient, CliError> {
-    let (profile_name, profile) = active_profile(global);
+    let (profile_name, profile, defaults) = active_profile(global);
 
     let api_key = resolve_cloud_api_key(profile.as_ref(), &profile_name, global)?;
     let controller = resolve_site_manager_url(profile.as_ref(), global);
-    let transport = cloud_transport(global, profile.as_ref().and_then(|p| p.timeout));
+    let transport = cloud_transport(
+        global,
+        profile.as_ref().and_then(|p| p.timeout),
+        Some(defaults.timeout),
+    );
 
     SiteManagerClient::from_api_key(&controller, &api_key, &transport).map_err(api_error)
 }
@@ -64,7 +68,7 @@ pub(crate) async fn build_cloud_integration_client(
 ) -> Result<IntegrationClient, CliError> {
     let api_key = resolve_cloud_api_key(Some(profile), profile_name, global)?;
     let controller = resolve_site_manager_url(Some(profile), global);
-    let transport = cloud_transport(global, profile.timeout);
+    let transport = cloud_transport(global, profile.timeout, None);
     let host_id = if let Some(host_id) = &global.host_id {
         host_id.clone()
     } else if let Ok(host_id) = config::resolve_host_id(profile) {
@@ -97,17 +101,21 @@ pub(crate) async fn load_cloud_connector_sites(
         .map_err(api_error)
 }
 
-pub(crate) fn active_profile(global: &GlobalOpts) -> (String, Option<Profile>) {
+pub(crate) fn active_profile(global: &GlobalOpts) -> (String, Option<Profile>, Defaults) {
     let cfg = config::resolve::load_config_or_default();
     let profile_name = config::resolve::active_profile_name(global, &cfg);
     let profile = cfg.profiles.get(&profile_name).cloned();
-    (profile_name, profile)
+    (profile_name, profile, cfg.defaults)
 }
 
-fn cloud_transport(global: &GlobalOpts, profile_timeout: Option<u64>) -> TransportConfig {
+fn cloud_transport(
+    global: &GlobalOpts,
+    profile_timeout: Option<u64>,
+    defaults_timeout: Option<u64>,
+) -> TransportConfig {
     TransportConfig {
         tls: TlsMode::System,
-        timeout: Duration::from_secs(global.timeout_secs(profile_timeout)),
+        timeout: Duration::from_secs(global.timeout_secs(profile_timeout, defaults_timeout)),
         cookie_jar: None,
     }
 }

--- a/crates/unifly/src/cli/commands/cloud.rs
+++ b/crates/unifly/src/cli/commands/cloud.rs
@@ -65,10 +65,11 @@ pub(crate) async fn build_cloud_integration_client(
     profile: &Profile,
     profile_name: &str,
     global: &GlobalOpts,
+    defaults_timeout: Option<u64>,
 ) -> Result<IntegrationClient, CliError> {
     let api_key = resolve_cloud_api_key(Some(profile), profile_name, global)?;
     let controller = resolve_site_manager_url(Some(profile), global);
-    let transport = cloud_transport(global, profile.timeout, None);
+    let transport = cloud_transport(global, profile.timeout, defaults_timeout);
     let host_id = if let Some(host_id) = &global.host_id {
         host_id.clone()
     } else if let Ok(host_id) = config::resolve_host_id(profile) {
@@ -93,8 +94,10 @@ pub(crate) async fn load_cloud_connector_sites(
     profile: &Profile,
     profile_name: &str,
     global: &GlobalOpts,
+    defaults_timeout: Option<u64>,
 ) -> Result<Vec<SiteResponse>, CliError> {
-    let integration = build_cloud_integration_client(profile, profile_name, global).await?;
+    let integration =
+        build_cloud_integration_client(profile, profile_name, global, defaults_timeout).await?;
     integration
         .paginate_all(50, |offset, limit| integration.list_sites(offset, limit))
         .await

--- a/crates/unifly/src/cli/commands/cloud/switch.rs
+++ b/crates/unifly/src/cli/commands/cloud/switch.rs
@@ -116,7 +116,9 @@ fn resolve_site<'a>(sites: &'a [SiteResponse], query: &str) -> Result<&'a SiteRe
 
 pub async fn handle(args: CloudSwitchArgs, global: &GlobalOpts) -> Result<(), CliError> {
     let (mut cfg, profile_name, profile) = require_cloud_profile(global)?;
-    let sites = load_cloud_connector_sites(&profile, &profile_name, global).await?;
+    let sites =
+        load_cloud_connector_sites(&profile, &profile_name, global, Some(cfg.defaults.timeout))
+            .await?;
     let site = resolve_site(&sites, &args.site)?;
 
     let Some(active_profile) = cfg.profiles.get_mut(&profile_name) else {

--- a/crates/unifly/src/cli/commands/config_cmd/interactive.rs
+++ b/crates/unifly/src/cli/commands/config_cmd/interactive.rs
@@ -234,6 +234,27 @@ fn build_cloud_integration_client(
     .map_err(cloud_api_error)
 }
 
+/// Guess whether a controller URL points at a LAN device that will present
+/// a self-signed certificate: bare IPs, single-label hostnames, and
+/// local-only suffixes default the wizard's TLS prompt to "yes", public
+/// hostnames to "no". Unparseable input is treated as local.
+fn likely_self_signed(controller: &str) -> bool {
+    let Ok(url) = url::Url::parse(controller) else {
+        return true;
+    };
+
+    match url.host() {
+        Some(url::Host::Ipv4(_) | url::Host::Ipv6(_)) | None => true,
+        Some(url::Host::Domain(domain)) => {
+            let domain = domain.trim_end_matches('.').to_ascii_lowercase();
+            !domain.contains('.')
+                || [".local", ".lan", ".home", ".internal", ".home.arpa"]
+                    .iter()
+                    .any(|suffix| domain.ends_with(suffix))
+        }
+    }
+}
+
 fn slugify_profile_name(name: &str) -> String {
     let mut slug = String::new();
     let mut last_dash = false;
@@ -500,6 +521,14 @@ pub(super) fn run_init(global: &GlobalOpts) -> Result<(), CliError> {
         .interact_text()
         .map_err(prompt_err)?;
 
+    // UDMs/UCGs ship self-signed certs; a profile without `insecure` fails
+    // TLS in every surface that doesn't pass -k (issue #25 root cause).
+    let insecure = Confirm::new()
+        .with_prompt("Does the controller use a self-signed certificate? (skips TLS verification)")
+        .default(likely_self_signed(&controller))
+        .interact()
+        .map_err(prompt_err)?;
+
     let auth_choices = &[
         "API Key (recommended)",
         "Username/Password",
@@ -612,7 +641,7 @@ pub(super) fn run_init(global: &GlobalOpts) -> Result<(), CliError> {
         password,
         totp_env: None,
         ca_cert: None,
-        insecure: None,
+        insecure: insecure.then_some(true),
         timeout: None,
     };
 
@@ -633,12 +662,15 @@ pub(super) fn run_init(global: &GlobalOpts) -> Result<(), CliError> {
     ui.meta("Profile", &ui.accent(&profile_name));
     ui.meta("Controller", &ui.accent(&controller_display));
     ui.meta("Site", &ui.accent(&site_display));
+    if insecure {
+        ui.meta("TLS", &ui.accent("accept self-signed (insecure = true)"));
+    }
     ui.meta(
         "Config path",
         &ui.accent(&config_path.display().to_string()),
     );
     eprintln!();
-    ui.meta("Try", &ui.keyword("unifly system info --insecure"));
+    ui.meta("Try", &ui.keyword("unifly system info"));
 
     Ok(())
 }
@@ -667,7 +699,7 @@ pub(super) async fn run_cloud_setup(global: &GlobalOpts) -> Result<(), CliError>
     let site_manager = build_site_manager_client(
         &controller,
         &api_key_setup.secret,
-        global.timeout_secs(None),
+        global.timeout_secs(None, None),
     )?;
 
     ui.step("Checking which consoles this API key can see...");
@@ -682,7 +714,7 @@ pub(super) async fn run_cloud_setup(global: &GlobalOpts) -> Result<(), CliError>
         &controller,
         &host.id,
         &api_key_setup.secret,
-        global.timeout_secs(None),
+        global.timeout_secs(None, None),
     )?;
     let sites = integration
         .paginate_all(50, |offset, limit| integration.list_sites(offset, limit))
@@ -782,7 +814,9 @@ pub(super) fn store_profile_secrets(profile_name: &str, auth_mode: &str) -> Resu
 mod tests {
     use std::collections::HashMap;
 
-    use super::{cloud_connector_url, next_available_profile_name, slugify_profile_name};
+    use super::{
+        cloud_connector_url, likely_self_signed, next_available_profile_name, slugify_profile_name,
+    };
     use crate::config::Profile;
 
     fn sample_profile() -> Profile {
@@ -816,6 +850,22 @@ mod tests {
         profiles.insert("work-2".into(), sample_profile());
 
         assert_eq!(next_available_profile_name("work", &profiles), "work-3");
+    }
+
+    #[test]
+    fn likely_self_signed_defaults_yes_for_local_controllers() {
+        assert!(likely_self_signed("https://192.168.1.1"));
+        assert!(likely_self_signed("https://[fe80::1]:8443"));
+        assert!(likely_self_signed("https://udm.local"));
+        assert!(likely_self_signed("https://gateway.lan"));
+        assert!(likely_self_signed("https://dream-machine"));
+        assert!(likely_self_signed("192.168.1.1"));
+    }
+
+    #[test]
+    fn likely_self_signed_defaults_no_for_public_hostnames() {
+        assert!(!likely_self_signed("https://unifi.example.com"));
+        assert!(!likely_self_signed("https://controller.example.com:8443"));
     }
 
     #[test]

--- a/crates/unifly/src/cli/commands/devices/render.rs
+++ b/crates/unifly/src/cli/commands/devices/render.rs
@@ -620,7 +620,7 @@ mod tests {
             verbose: 0,
             quiet: false,
             yes: false,
-            insecure: false,
+            insecure: None,
             timeout: None,
             no_effects: false,
         })

--- a/crates/unifly/src/config/mod.rs
+++ b/crates/unifly/src/config/mod.rs
@@ -527,9 +527,12 @@ pub fn resolve_totp_token(profile: &Profile) -> Option<SecretString> {
 ///
 /// Suitable for the TUI and other non-CLI consumers. Sets TUI-friendly
 /// defaults: `websocket_enabled: true`, `refresh_interval_secs: 10`.
+/// `[defaults]` supplies `insecure` and `timeout` when the profile
+/// leaves them unset, mirroring the CLI resolution ladder.
 pub fn profile_to_controller_config(
     profile: &Profile,
     profile_name: &str,
+    defaults: &Defaults,
 ) -> Result<ControllerConfig, ConfigError> {
     let is_cloud = profile.auth_mode == "cloud";
     let controller_url = if is_cloud && profile.controller.trim().is_empty() {
@@ -547,17 +550,21 @@ pub fn profile_to_controller_config(
 
     let auth = resolve_auth(profile, profile_name)?;
 
+    // Profile insecure > profile ca_cert > defaults insecure: a CA is
+    // still verification, so only an explicit insecure=true skips it.
     let tls = if is_cloud {
         TlsVerification::SystemDefaults
     } else if profile.insecure.unwrap_or(false) {
         TlsVerification::DangerAcceptInvalid
     } else if let Some(ref ca_path) = profile.ca_cert {
         TlsVerification::CustomCa(ca_path.clone())
+    } else if profile.insecure.unwrap_or(defaults.insecure) {
+        TlsVerification::DangerAcceptInvalid
     } else {
         TlsVerification::SystemDefaults
     };
 
-    let timeout = Duration::from_secs(profile.timeout.unwrap_or(30));
+    let timeout = Duration::from_secs(profile.timeout.unwrap_or(defaults.timeout));
 
     let totp_token = resolve_totp_token(profile);
 
@@ -579,10 +586,11 @@ pub fn profile_to_controller_config(
 #[cfg(test)]
 mod tests {
     use super::{
-        DEFAULT_CLOUD_CONTROLLER_URL, Profile, profile_to_controller_config, resolve_api_key,
-        resolve_auth,
+        DEFAULT_CLOUD_CONTROLLER_URL, Defaults, Profile, profile_to_controller_config,
+        resolve_api_key, resolve_auth,
     };
     use secrecy::ExposeSecret;
+    use std::time::Duration;
     use unifly_api::{AuthCredentials, TlsVerification};
 
     fn cloud_profile() -> Profile {
@@ -646,8 +654,8 @@ mod tests {
     fn profile_to_controller_config_defaults_cloud_transport() {
         let profile = cloud_profile();
 
-        let config =
-            profile_to_controller_config(&profile, "cloud").expect("cloud config should resolve");
+        let config = profile_to_controller_config(&profile, "cloud", &Defaults::default())
+            .expect("cloud config should resolve");
 
         assert_eq!(
             config.url.as_str(),
@@ -658,5 +666,47 @@ mod tests {
         assert_eq!(config.refresh_interval_secs, 60);
         assert_eq!(config.polling_interval_secs, 30);
         assert!(config.no_session_cache);
+    }
+
+    fn direct_profile() -> Profile {
+        let mut profile = cloud_profile();
+        profile.auth_mode = "integration".into();
+        profile.controller = "https://10.0.1.1".into();
+        profile.insecure = None;
+        profile.timeout = None;
+        profile
+    }
+
+    #[test]
+    fn profile_to_controller_config_applies_defaults_insecure_and_timeout() {
+        let profile = direct_profile();
+
+        let defaults = Defaults {
+            insecure: true,
+            timeout: 77,
+            ..Defaults::default()
+        };
+
+        let config = profile_to_controller_config(&profile, "default", &defaults)
+            .expect("profile should resolve");
+
+        assert!(matches!(config.tls, TlsVerification::DangerAcceptInvalid));
+        assert_eq!(config.timeout, Duration::from_secs(77));
+    }
+
+    #[test]
+    fn profile_to_controller_config_ca_cert_beats_defaults_insecure() {
+        let mut profile = direct_profile();
+        profile.ca_cert = Some("/certs/controller-ca.pem".into());
+
+        let defaults = Defaults {
+            insecure: true,
+            ..Defaults::default()
+        };
+
+        let config = profile_to_controller_config(&profile, "default", &defaults)
+            .expect("profile should resolve");
+
+        assert!(matches!(config.tls, TlsVerification::CustomCa(_)));
     }
 }

--- a/crates/unifly/src/config/resolve.rs
+++ b/crates/unifly/src/config/resolve.rs
@@ -25,11 +25,15 @@ pub const DEFAULT_TIMEOUT_SECS: u64 = 30;
 // because build.rs includes args.rs standalone for man-page generation,
 // and that compilation unit must stay pure clap definitions.
 impl GlobalOpts {
-    /// Resolve the effective timeout: flag/env, then profile, then default.
+    /// Resolve the effective timeout: flag/env, then profile, then
+    /// `[defaults]`, then the builtin fallback.
+    ///
+    /// Callers without a loaded config pass `None` for `defaults_timeout`.
     #[must_use]
-    pub fn timeout_secs(&self, profile_timeout: Option<u64>) -> u64 {
+    pub fn timeout_secs(&self, profile_timeout: Option<u64>, defaults_timeout: Option<u64>) -> u64 {
         self.timeout
             .or(profile_timeout)
+            .or(defaults_timeout)
             .unwrap_or(DEFAULT_TIMEOUT_SECS)
     }
 }
@@ -45,11 +49,12 @@ pub fn active_profile_name(global: &GlobalOpts, cfg: &Config) -> String {
 
 /// Translate a `Profile` + global flags into a `ControllerConfig`.
 ///
-/// CLI flag overrides take priority over profile values.
+/// Precedence: CLI flags > env > profile > `[defaults]` > builtin.
 pub fn resolve_profile(
     profile: &Profile,
     profile_name: &str,
     global: &GlobalOpts,
+    defaults: &Defaults,
 ) -> Result<ControllerConfig, CliError> {
     let is_cloud = profile.auth_mode == "cloud";
 
@@ -100,10 +105,10 @@ pub fn resolve_profile(
         }
     };
 
-    // 3. TLS verification
+    // 3. TLS verification (flag > profile > defaults)
     let tls = if is_cloud {
         TlsVerification::SystemDefaults
-    } else if global.insecure || profile.insecure.unwrap_or(false) {
+    } else if global.insecure || profile.insecure.unwrap_or(defaults.insecure) {
         TlsVerification::DangerAcceptInvalid
     } else if let Some(ref ca_path) = profile.ca_cert {
         TlsVerification::CustomCa(ca_path.clone())
@@ -114,8 +119,8 @@ pub fn resolve_profile(
     // 4. Site (flag > env > profile)
     let site = global.site.as_deref().unwrap_or(&profile.site).to_string();
 
-    // 5. Timeout (flag/env > profile > default)
-    let timeout = Duration::from_secs(global.timeout_secs(profile.timeout));
+    // 5. Timeout (flag/env > profile > defaults > builtin)
+    let timeout = Duration::from_secs(global.timeout_secs(profile.timeout, Some(defaults.timeout)));
 
     // 6. TOTP (flag > env var from profile's totp_env)
     let totp_token = resolve_totp_with_flag(profile, global);
@@ -167,9 +172,11 @@ fn resolve_host_id_with_flag(profile: &Profile, global: &GlobalOpts) -> Result<S
 
 #[cfg(test)]
 mod tests {
+    use std::time::Duration;
+
     use super::resolve_profile;
     use crate::cli::args::{ColorMode, GlobalOpts, OutputFormat};
-    use crate::config::Profile;
+    use crate::config::{Defaults, Profile};
     use unifly_api::{AuthCredentials, TlsVerification};
 
     fn base_global() -> GlobalOpts {
@@ -212,13 +219,22 @@ mod tests {
         }
     }
 
+    fn direct_profile() -> Profile {
+        let mut profile = cloud_profile();
+        profile.auth_mode = "integration".into();
+        profile.controller = "https://10.0.1.1".into();
+        profile.insecure = None;
+        profile.timeout = None;
+        profile
+    }
+
     #[test]
     fn resolve_profile_supports_cloud_defaults_and_flag_override() {
         let profile = cloud_profile();
         let global = base_global();
 
-        let resolved =
-            resolve_profile(&profile, "cloud", &global).expect("cloud profile should resolve");
+        let resolved = resolve_profile(&profile, "cloud", &global, &Defaults::default())
+            .expect("cloud profile should resolve");
 
         assert_eq!(resolved.url.as_str(), "https://api.ui.com/");
         assert!(matches!(resolved.tls, TlsVerification::SystemDefaults));
@@ -237,18 +253,119 @@ mod tests {
         // The TUI launch path resolves profiles through this function; the
         // -k/--insecure flag must win when the profile leaves TLS unset
         // (issue #25: flag was dropped, TLS failed, TUI sat disconnected).
-        let mut profile = cloud_profile();
-        profile.auth_mode = "integration".into();
-        profile.controller = "https://10.0.1.1".into();
-        profile.insecure = None;
+        let profile = direct_profile();
 
         let global = base_global();
         assert!(global.insecure);
 
-        let resolved =
-            resolve_profile(&profile, "default", &global).expect("profile should resolve");
+        let resolved = resolve_profile(&profile, "default", &global, &Defaults::default())
+            .expect("profile should resolve");
 
         assert!(matches!(resolved.tls, TlsVerification::DangerAcceptInvalid));
+    }
+
+    #[test]
+    fn resolve_profile_applies_defaults_insecure_when_flag_and_profile_unset() {
+        let profile = direct_profile();
+        let mut global = base_global();
+        global.insecure = false;
+
+        let defaults = Defaults {
+            insecure: true,
+            ..Defaults::default()
+        };
+
+        let resolved = resolve_profile(&profile, "default", &global, &defaults)
+            .expect("profile should resolve");
+
+        assert!(matches!(resolved.tls, TlsVerification::DangerAcceptInvalid));
+    }
+
+    #[test]
+    fn resolve_profile_profile_insecure_overrides_defaults() {
+        let mut profile = direct_profile();
+        profile.insecure = Some(false);
+
+        let mut global = base_global();
+        global.insecure = false;
+
+        let defaults = Defaults {
+            insecure: true,
+            ..Defaults::default()
+        };
+
+        let resolved = resolve_profile(&profile, "default", &global, &defaults)
+            .expect("profile should resolve");
+
+        assert!(matches!(resolved.tls, TlsVerification::SystemDefaults));
+    }
+
+    #[test]
+    fn resolve_profile_insecure_flag_overrides_profile_and_defaults() {
+        let mut profile = direct_profile();
+        profile.insecure = Some(false);
+
+        let global = base_global();
+        assert!(global.insecure);
+
+        let resolved = resolve_profile(&profile, "default", &global, &Defaults::default())
+            .expect("profile should resolve");
+
+        assert!(matches!(resolved.tls, TlsVerification::DangerAcceptInvalid));
+    }
+
+    #[test]
+    fn resolve_profile_applies_defaults_timeout_when_flag_and_profile_unset() {
+        let profile = direct_profile();
+        let global = base_global();
+        assert!(global.timeout.is_none());
+
+        let defaults = Defaults {
+            timeout: 77,
+            ..Defaults::default()
+        };
+
+        let resolved = resolve_profile(&profile, "default", &global, &defaults)
+            .expect("profile should resolve");
+
+        assert_eq!(resolved.timeout, Duration::from_secs(77));
+    }
+
+    #[test]
+    fn resolve_profile_profile_timeout_overrides_defaults() {
+        let mut profile = direct_profile();
+        profile.timeout = Some(45);
+
+        let global = base_global();
+
+        let defaults = Defaults {
+            timeout: 77,
+            ..Defaults::default()
+        };
+
+        let resolved = resolve_profile(&profile, "default", &global, &defaults)
+            .expect("profile should resolve");
+
+        assert_eq!(resolved.timeout, Duration::from_secs(45));
+    }
+
+    #[test]
+    fn resolve_profile_timeout_flag_overrides_profile_and_defaults() {
+        let mut profile = direct_profile();
+        profile.timeout = Some(45);
+
+        let mut global = base_global();
+        global.timeout = Some(5);
+
+        let defaults = Defaults {
+            timeout: 77,
+            ..Defaults::default()
+        };
+
+        let resolved = resolve_profile(&profile, "default", &global, &defaults)
+            .expect("profile should resolve");
+
+        assert_eq!(resolved.timeout, Duration::from_secs(5));
     }
 
     #[test]
@@ -257,7 +374,7 @@ mod tests {
         let mut global = base_global();
         global.host_id = None;
 
-        let resolved = resolve_profile(&profile, "cloud", &global)
+        let resolved = resolve_profile(&profile, "cloud", &global, &Defaults::default())
             .expect("profile fallback host id should still resolve");
 
         match resolved.auth {

--- a/crates/unifly/src/config/resolve.rs
+++ b/crates/unifly/src/config/resolve.rs
@@ -105,13 +105,20 @@ pub fn resolve_profile(
         }
     };
 
-    // 3. TLS verification (flag > profile > defaults)
+    // 3. TLS verification (flag/env > profile insecure > profile ca_cert
+    //    > defaults insecure). An explicit `--insecure=false` re-enables
+    //    verification, and a profile CA is still verification, so only an
+    //    explicit insecure=true may skip it; [defaults].insecure applies
+    //    when neither flag nor profile decided and no CA is configured.
+    let explicit_insecure = global.insecure.or(profile.insecure);
     let tls = if is_cloud {
         TlsVerification::SystemDefaults
-    } else if global.insecure || profile.insecure.unwrap_or(defaults.insecure) {
+    } else if explicit_insecure.unwrap_or(false) {
         TlsVerification::DangerAcceptInvalid
     } else if let Some(ref ca_path) = profile.ca_cert {
         TlsVerification::CustomCa(ca_path.clone())
+    } else if explicit_insecure.unwrap_or(defaults.insecure) {
+        TlsVerification::DangerAcceptInvalid
     } else {
         TlsVerification::SystemDefaults
     };
@@ -195,7 +202,7 @@ mod tests {
             totp: None,
             no_cache: false,
             demo: false,
-            insecure: true,
+            insecure: Some(true),
             timeout: None,
             no_effects: false,
         }
@@ -256,7 +263,7 @@ mod tests {
         let profile = direct_profile();
 
         let global = base_global();
-        assert!(global.insecure);
+        assert_eq!(global.insecure, Some(true));
 
         let resolved = resolve_profile(&profile, "default", &global, &Defaults::default())
             .expect("profile should resolve");
@@ -268,7 +275,7 @@ mod tests {
     fn resolve_profile_applies_defaults_insecure_when_flag_and_profile_unset() {
         let profile = direct_profile();
         let mut global = base_global();
-        global.insecure = false;
+        global.insecure = None;
 
         let defaults = Defaults {
             insecure: true,
@@ -287,7 +294,7 @@ mod tests {
         profile.insecure = Some(false);
 
         let mut global = base_global();
-        global.insecure = false;
+        global.insecure = None;
 
         let defaults = Defaults {
             insecure: true,
@@ -306,12 +313,50 @@ mod tests {
         profile.insecure = Some(false);
 
         let global = base_global();
-        assert!(global.insecure);
+        assert_eq!(global.insecure, Some(true));
 
         let resolved = resolve_profile(&profile, "default", &global, &Defaults::default())
             .expect("profile should resolve");
 
         assert!(matches!(resolved.tls, TlsVerification::DangerAcceptInvalid));
+    }
+
+    #[test]
+    fn resolve_profile_insecure_flag_false_overrides_profile_and_defaults() {
+        let mut profile = direct_profile();
+        profile.insecure = Some(true);
+
+        let mut global = base_global();
+        global.insecure = Some(false);
+
+        let defaults = Defaults {
+            insecure: true,
+            ..Defaults::default()
+        };
+
+        let resolved = resolve_profile(&profile, "default", &global, &defaults)
+            .expect("profile should resolve");
+
+        assert!(matches!(resolved.tls, TlsVerification::SystemDefaults));
+    }
+
+    #[test]
+    fn resolve_profile_profile_ca_cert_beats_defaults_insecure() {
+        let mut profile = direct_profile();
+        profile.ca_cert = Some("/certs/controller-ca.pem".into());
+
+        let mut global = base_global();
+        global.insecure = None;
+
+        let defaults = Defaults {
+            insecure: true,
+            ..Defaults::default()
+        };
+
+        let resolved = resolve_profile(&profile, "default", &global, &defaults)
+            .expect("profile should resolve");
+
+        assert!(matches!(resolved.tls, TlsVerification::CustomCa(_)));
     }
 
     #[test]

--- a/crates/unifly/src/tui/mod.rs
+++ b/crates/unifly/src/tui/mod.rs
@@ -166,7 +166,7 @@ fn build_controller_direct(global: &GlobalOpts) -> Option<Controller> {
         auth,
         site,
         tls,
-        timeout: std::time::Duration::from_secs(global.timeout_secs(None)),
+        timeout: std::time::Duration::from_secs(global.timeout_secs(None, None)),
         refresh_interval_secs: if is_cloud { 60 } else { 10 },
         websocket_enabled: !is_cloud,
         polling_interval_secs: if is_cloud { 30 } else { 10 },
@@ -226,7 +226,7 @@ fn build_controller_from_config(global: &GlobalOpts) -> Option<Controller> {
     // The CLI resolver honors flag/env overrides (--insecure, --site,
     // --api-key, --totp, --no-cache) that the plain profile translation
     // does not; dropping them here is how issue #25 happened.
-    match config::resolve::resolve_profile(profile, profile_name, global) {
+    match config::resolve::resolve_profile(profile, profile_name, global, &cfg.defaults) {
         Ok(mut controller_config) => {
             let is_cloud = matches!(controller_config.auth, AuthCredentials::Cloud { .. });
             controller_config.refresh_interval_secs = if is_cloud { 60 } else { 10 };

--- a/crates/unifly/src/tui/mod.rs
+++ b/crates/unifly/src/tui/mod.rs
@@ -148,7 +148,7 @@ fn build_controller_direct(global: &GlobalOpts) -> Option<Controller> {
 
     let tls = if is_cloud {
         TlsVerification::SystemDefaults
-    } else if global.insecure {
+    } else if global.insecure.unwrap_or(false) {
         TlsVerification::DangerAcceptInvalid
     } else {
         TlsVerification::SystemDefaults

--- a/crates/unifly/src/tui/screens/onboarding/state.rs
+++ b/crates/unifly/src/tui/screens/onboarding/state.rs
@@ -112,8 +112,14 @@ impl OnboardingScreen {
         };
 
         tokio::spawn(async move {
-            let result = match crate::config::profile_to_controller_config(&profile, &profile_name)
-            {
+            let defaults = crate::config::load_config()
+                .map(|cfg| cfg.defaults)
+                .unwrap_or_default();
+            let result = match crate::config::profile_to_controller_config(
+                &profile,
+                &profile_name,
+                &defaults,
+            ) {
                 Ok(config) => {
                     let controller = unifly_api::Controller::new(config);
                     match controller.connect().await {
@@ -153,7 +159,10 @@ impl OnboardingScreen {
             return;
         };
 
-        match crate::config::profile_to_controller_config(&profile, profile_name) {
+        let defaults = crate::config::load_config()
+            .map(|cfg| cfg.defaults)
+            .unwrap_or_default();
+        match crate::config::profile_to_controller_config(&profile, profile_name, &defaults) {
             Ok(config) => {
                 let _ = tx.send(crate::tui::action::Action::OnboardingComplete {
                     profile_name: profile_name.to_string(),

--- a/crates/unifly/src/tui/screens/settings/state.rs
+++ b/crates/unifly/src/tui/screens/settings/state.rs
@@ -250,8 +250,14 @@ impl SettingsScreen {
         };
 
         tokio::spawn(async move {
-            let result = match crate::config::profile_to_controller_config(&profile, &profile_name)
-            {
+            let defaults = crate::config::load_config()
+                .map(|cfg| cfg.defaults)
+                .unwrap_or_default();
+            let result = match crate::config::profile_to_controller_config(
+                &profile,
+                &profile_name,
+                &defaults,
+            ) {
                 Ok(config) => {
                     let controller = unifly_api::Controller::new(config);
                     match controller.connect().await {
@@ -284,7 +290,10 @@ impl SettingsScreen {
             return;
         };
 
-        match crate::config::profile_to_controller_config(&profile, &self.profile_name) {
+        let defaults = crate::config::load_config()
+            .map(|cfg| cfg.defaults)
+            .unwrap_or_default();
+        match crate::config::profile_to_controller_config(&profile, &self.profile_name, &defaults) {
             Ok(config) => {
                 let _ = tx.send(crate::tui::action::Action::SettingsApply {
                     profile_name: self.profile_name.clone(),

--- a/skills/unifly/examples/config.toml
+++ b/skills/unifly/examples/config.toml
@@ -4,6 +4,12 @@
 # Default profile to use when --profile is not specified
 default_profile = "home"
 
+# Global fallbacks applied when a profile leaves a value unset.
+# Precedence: CLI flags > env vars > profile > [defaults] > builtin.
+[defaults]
+insecure = false # accept self-signed certificates when true
+timeout = 30     # request timeout in seconds
+
 # Home controller: UDM Pro with hybrid auth
 [profiles.home]
 controller = "https://192.168.1.1"


### PR DESCRIPTION
## 🎯 What

`unifly config init` now asks about self-signed certificates and writes `insecure = true` into the profile when confirmed, and the `[defaults]` config section's `insecure` and `timeout` fields actually take effect.

## 🔍 Why

The init wizard wrote `insecure: None` unconditionally and then told the user to pass `--insecure` — the canonical setup for a UDM/UCG with a self-signed cert produced a profile that failed TLS on every surface that did not pass `-k`. That trap is the same family as issue #25. Separately, `[defaults] insecure` and `[defaults] timeout` were parsed and displayed by `config show` but consulted by nothing.

## 🛠️ How

- The wizard asks "Does the controller use a self-signed certificate?" right after the URL prompt (init is fully offline, so there is no connectivity-test hook point). The default answer comes from a `likely_self_signed` heuristic: yes for IP literals, single-label hostnames, and `.local`/`.lan`/`.home`/`.internal`/`.home.arpa` suffixes; no for public multi-label hostnames. Declining writes `None` so the profile still falls through to `[defaults]`.
- Resolution now follows the documented precedence end to end: flag/env, then profile, then `[defaults]`, then builtin. `resolve_profile` takes the `Defaults` layer as a parameter; an explicit `insecure = false` on a profile beats `[defaults] insecure = true`. An absent `[defaults]` section behaves identically to before.
- The cloud fleet transport honors `defaults.timeout` too; the pre-config wizard paths pass an empty defaults layer since no config exists yet.
- `examples/config.toml` documents the `[defaults]` block and the precedence.

## 🧪 Testing

- Six new resolution tests cover the full ladder for both fields (defaults apply when unset above, profile beats defaults, flag beats both), plus two tests for the `likely_self_signed` heuristic.
- `cargo clippy --locked --workspace --all-targets -- -D warnings` clean; full workspace suite green (501 tests across 11 suites).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added global configuration defaults for certificate verification and request timeouts.
  - Default timeout settings now apply when profile-specific values are not configured.
  - Interactive setup detects likely self-signed certificates and recommends the appropriate TLS verification setting.
  - Setup saves the selected certificate option and updates the suggested follow-up command.

- **Documentation**
  - Added configuration examples and documented timeout and TLS setting precedence in the changelog.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->