### PR TITLE
docs(site): bring the docs site up to the 0.10.0 surface

### DIFF
--- a/docs/content/architecture/_index.md
+++ b/docs/content/architecture/_index.md
@@ -32,13 +32,14 @@ The `DataStore` uses `DashMap` for lock-free concurrent reads and `tokio::watch`
 
 ## Key Types
 
-| Type              | Purpose                                                                              |
-| ----------------- | ------------------------------------------------------------------------------------ |
-| `Controller`      | Main entry point. Wraps `Arc<ControllerInner>` for cheap cloning across async tasks  |
-| `DataStore`       | Entity storage. `DashMap` + `watch` channels for lock-free reactive updates          |
-| `EntityStream<T>` | Reactive subscription. Wraps `watch::Receiver` with `current()`/`changed()` API      |
-| `EntityId`        | Dual-identity. `Uuid(Uuid)` or `Legacy(String)` for entities that exist in both APIs |
-| `AuthCredentials` | Auth mode. `ApiKey`, `Credentials`, `Hybrid`, or `Cloud` variants                    |
+| Type                | Purpose                                                                              |
+| ------------------- | ------------------------------------------------------------------------------------ |
+| `Controller`        | Main entry point. Wraps `Arc<ControllerInner>` for cheap cloning across async tasks  |
+| `DataStore`         | Entity storage. `DashMap` + `watch` channels for lock-free reactive updates          |
+| `EntityStream<T>`   | Reactive subscription. Wraps `watch::Receiver` with `current()`/`changed()` API      |
+| `EntityId`          | Dual-identity. `Uuid(Uuid)` or `Legacy(String)` for entities that exist in both APIs |
+| `AuthCredentials`   | Auth mode. `ApiKey`, `Credentials`, `Hybrid`, or `Cloud` variants                    |
+| `SiteManagerClient` | Cloud fleet client for `api.ui.com` (consoles, sites, devices, ISP, SD-WAN)          |
 
 ## Next Steps
 

--- a/docs/content/architecture/api-surface.md
+++ b/docs/content/architecture/api-surface.md
@@ -4,7 +4,7 @@ description = "Integration API, Session API, and Site Manager endpoints"
 weight = 3
 +++
 
-Unifly communicates with UniFi controllers through two distinct API interfaces, each with different authentication mechanisms and capabilities.
+Unifly communicates with UniFi infrastructure through three distinct API interfaces, each with different authentication mechanisms and capabilities: the Integration API and Session API on the controller itself, and the Site Manager API in Ubiquiti's cloud.
 
 ## Integration API
 
@@ -27,7 +27,7 @@ Devices, clients, networks, WiFi (WLANs), firewall policies, firewall zones, ACL
 - No historical statistics
 - No alarm management
 
-Legacy still owns the live and historical monitoring surfaces: event streaming, stats/reporting, and admin workflows.
+The Session API still owns the live and historical monitoring surfaces: event streaming, stats/reporting, and admin workflows.
 
 ## Session API
 
@@ -49,10 +49,13 @@ The original UniFi controller API, session-based with cookie authentication.
 - `stat/report/`: Historical bandwidth and client reports
 - `cmd/sitemgr`: Device commands (adopt, restart, upgrade)
 - `stat/admin`: Administrator management
+- `rest/firewallgroup`: Firewall groups (port and address groups)
+- `rest/setting` / `set/setting/{key}`: Site-level settings sections
+- Switch port overrides (`devices ports` / `port-set`): the Integration API does not expose port VLAN configuration
 
 ### v2 Endpoints
 
-Network Application 9+ exposes a second generation of legacy-authenticated endpoints under `/v2/api/site/{site}/`. These return plain JSON (no `{ meta, data }` envelope).
+Network Application 9+ exposes a second generation of session-authenticated endpoints under `/v2/api/site/{site}/`. These return plain JSON (no `{ meta, data }` envelope).
 
 | Endpoint                         | Description                                   |
 | -------------------------------- | --------------------------------------------- |
@@ -93,6 +96,22 @@ When configured with both an API key and credentials, unifly uses each API for w
 | System health (ISP, DNS, gateway)       | Session API                   |
 
 This provides the most complete feature set while using the cleanest API surface available for each operation.
+
+## Site Manager API
+
+Ubiquiti's cloud API for fleets of consoles, spoken by the `SiteManagerClient`.
+
+| Aspect       | Details                                        |
+| ------------ | ---------------------------------------------- |
+| **Auth**     | Site Manager API key via `X-API-KEY` header    |
+| **Base URL** | `https://api.ui.com/v1/`                       |
+| **Format**   | Plain JSON                                     |
+| **Scope**    | Account-wide: every console the key can access |
+
+Two surfaces run on the same key:
+
+- **Fleet endpoints**: hosts (consoles), sites, devices across the fleet, ISP metrics, and SD-WAN configs. These back the `unifly cloud` command group and need no controller connection.
+- **Cloud connector**: `https://api.ui.com/v1/connector/consoles/{host_id}` proxies the console's **Integration API**, so a cloud-mode profile can run the regular Integration-backed commands against a console with no direct network path. Session endpoints are not proxied; session-backed features require direct controller access.
 
 ## Error Handling
 

--- a/docs/content/architecture/crates.md
+++ b/docs/content/architecture/crates.md
@@ -14,6 +14,7 @@ Published on [crates.io](https://crates.io/crates/unifly-api). The engine poweri
 
 - **Integration API client**: RESTful endpoints with API key authentication
 - **Session API client**: Session-based with cookie and CSRF token handling
+- **Site Manager client**: Ubiquiti cloud fleet API (`api.ui.com`) with API key authentication
 - **WebSocket client**: Real-time event streaming
 - **TLS**: Custom `rustls` configuration for self-signed certificates
 
@@ -46,7 +47,7 @@ graphics-protocol charts are opt-in with `tui-graphics`.
 
 ### CLI (`unifly`)
 
-- **clap-derived** command tree with 26 top-level commands
+- **clap-derived** command tree with 28 top-level commands
 - **Output formatting**: Table, JSON, YAML, plain text via `tabled`
 - **Shell completions**: Bash, Zsh, Fish via `clap_complete`
 - **Man pages**: Generated at build time via `clap_mangen`

--- a/docs/content/architecture/data-flow.md
+++ b/docs/content/architecture/data-flow.md
@@ -11,17 +11,17 @@ sequenceDiagram
 participant User
 participant Controller
 participant IntegrationAPI
-participant LegacyAPI
+participant SessionAPI
 participant WebSocket
 participant DataStore
 
     User->>Controller: connect()
     Controller->>IntegrationAPI: Authenticate (API key)
-    Controller->>LegacyAPI: Authenticate (cookie + CSRF)
+    Controller->>SessionAPI: Authenticate (cookie + CSRF)
     Controller->>IntegrationAPI: Fetch all entities
     IntegrationAPI-->>DataStore: Store devices, clients, networks...
-    Controller->>LegacyAPI: Fetch events, health
-    LegacyAPI-->>DataStore: Store events, health summaries
+    Controller->>SessionAPI: Fetch events, health
+    SessionAPI-->>DataStore: Store events, health summaries
     Controller->>WebSocket: Connect event stream
     Controller->>Controller: Spawn refresh task (10s)
     Controller->>Controller: Spawn command processor
@@ -68,7 +68,7 @@ Entities can have different IDs depending on the API source:
 | API         | ID Format       | Example                                |
 | ----------- | --------------- | -------------------------------------- |
 | Integration | UUID v4         | `a1b2c3d4-e5f6-7890-abcd-ef1234567890` |
-| Legacy      | MAC address     | `fc:ec:da:ab:cd:ef`                    |
+| Session     | ObjectId string | `66a1b2c3d4e5f60718293a4b`             |
 | Synthetic   | Prefixed string | `net:a1b2c3d4`, `wifi:e5f6a7b8`        |
 
 The `EntityId` enum handles this transparently:
@@ -76,11 +76,11 @@ The `EntityId` enum handles this transparently:
 ```rust
 enum EntityId {
     Uuid(Uuid),      // Integration API entities
-    Legacy(String),  // Session API entities (MAC-based)
+    Legacy(String),  // Session API entities (`_id` ObjectId strings)
 }
 ```
 
-Non-MAC entities (networks, WiFi, firewall policies) use synthetic keys with a type prefix to avoid collisions in the shared `DashMap`.
+The `Legacy` variant holds the Session API's MongoDB-style `_id` string. Some domain types (clients, devices) key on MAC address as their natural identifier instead, and non-MAC entities (networks, WiFi, firewall policies) use synthetic keys with a type prefix to avoid collisions in the shared `DashMap`.
 
 ## CLI vs TUI Data Patterns
 

--- a/docs/content/guide/_index.md
+++ b/docs/content/guide/_index.md
@@ -12,20 +12,26 @@ Both are powered by a shared async engine that speaks every UniFi API dialect, s
 
 ## The Problem
 
-UniFi controllers expose two completely different APIs:
+UniFi infrastructure speaks three completely different APIs:
 
 {% mermaid() %}
 graph LR
 subgraph "Integration API"
 I["REST + API Key"]
 I1["Networks, WiFi, Firewall"]
-I2["DNS, ACL, NAT, Traffic Lists"]
+I2["DNS, ACL, Traffic Lists"]
 end
 
     subgraph "Session API"
         S["Cookie + CSRF"]
-        S1["Events, Stats, DPI"]
+        S1["Events, Stats, DPI, NAT"]
         S2["Device Commands, Admin"]
+    end
+
+    subgraph "Site Manager"
+        M["api.ui.com + API Key"]
+        M1["Fleet: Consoles, Sites"]
+        M2["Cloud Connector"]
     end
 
     subgraph unifly
@@ -34,6 +40,7 @@ end
 
     I --> U
     S --> U
+    M --> U
     U --> CLI["CLI Output"]
     U --> TUI["TUI Dashboard"]
 
@@ -41,8 +48,9 @@ end
 
 - **Integration API**: RESTful, API-key authenticated, covers CRUD for most resources
 - **Session API**: Session-based with cookie/CSRF, required for events, statistics, and device commands
+- **Site Manager API**: Ubiquiti's cloud fleet API, for multi-console queries and connector-routed access without a VPN to the controller
 
-Most tools only speak one dialect. The web dashboard is slow and can't be scripted. Unifly handles the routing, authentication, and data merging automatically.
+Most tools speak one dialect, maybe two. The web dashboard is slow and can't be scripted. Unifly handles the routing, authentication, and data merging across all three automatically.
 
 ## What You Can Do
 
@@ -52,8 +60,12 @@ Most tools only speak one dialect. The web dashboard is slow and can't be script
 | **Client Monitoring**     | See connected clients with signal, traffic, and VLAN info                                         |
 | **Network Configuration** | Manage VLANs, subnets, DHCP, and IPv6 settings                                                    |
 | **WiFi Management**       | Create and modify SSIDs, scan neighbors, analyze channels, track client roams and WiFi experience |
-| **Firewall**              | Manage policies, zones, and ACL rules                                                             |
-| **NAT**                   | Masquerade, source NAT, and destination NAT rules (via Legacy v2 API)                             |
+| **Firewall**              | Manage policies, zones, groups, and ACL rules                                                     |
+| **NAT**                   | Masquerade, source NAT, and destination NAT rules (via Session v2 API)                            |
+| **VPN**                   | Site-to-site, remote-access, WireGuard peers, client VPNs, and OpenVPN config export              |
+| **Switch Ports**          | Port profiles as reviewable JSONC files: export, edit, apply, diff                                |
+| **Site Settings**         | Read and write every site-level settings section from the terminal                                |
+| **Cloud Fleet**           | Query consoles, sites, and devices across your whole fleet via Site Manager                       |
 | **Events & Alarms**       | Stream live events, acknowledge and archive alarms                                                |
 | **Statistics**            | Query bandwidth, client counts, and DPI data over time                                            |
 | **Raw API Access**        | Hit any controller endpoint directly with `unifly api`                                            |

--- a/docs/content/guide/agents.md
+++ b/docs/content/guide/agents.md
@@ -1,7 +1,7 @@
 +++
 title = "AI Agent Skill"
 description = "Teach AI coding agents to manage your UniFi network"
-weight = 5
+weight = 9
 +++
 
 Unifly ships with a dedicated skill bundle that teaches AI coding agents how to manage your UniFi network infrastructure. Your agent gets the full CLI reference, automation workflows, and a ready-made network manager agent.
@@ -23,7 +23,7 @@ npx skills add hyperb1iss/unifly -a claude-code
 
 {% mermaid() %}
 graph TD
-SKILL["unifly Skill Bundle"] --> REF["Command Reference<br/><i>27 commands, flags, gotchas</i>"]
+SKILL["unifly Skill Bundle"] --> REF["Command Reference<br/><i>28 commands, flags, gotchas</i>"]
 SKILL --> AGENT["Network Manager Agent<br/><i>Autonomous provisioning</i>"]
 SKILL --> CONCEPTS["Networking Concepts<br/><i>Dual-API architecture, auth</i>"]
 SKILL --> WORKFLOWS["Workflow Patterns<br/><i>Automation recipes</i>"]
@@ -40,7 +40,7 @@ SKILL --> EXAMPLES["Example Payloads<br/><i>JSON templates for --from-file</i>"]
 | **Network Manager agent** | Autonomous agent for provisioning VLANs, auditing firewalls, diagnosing connectivity       |
 | **Reference docs**        | UniFi networking concepts, dual-API gate matrix, auth decision tree                        |
 | **Workflow patterns**     | Runnable recipes for event streaming, firewall reordering, DHCP reservations, DNS policies |
-| **Example payloads**      | JSON templates for `--from-file` (networks, firewall, NAT, WiFi)                           |
+| **Example payloads**      | JSON templates for `--from-file` (networks, firewall, NAT, WiFi, VPN, switch ports)        |
 
 ## What Your Agent Can Do
 

--- a/docs/content/guide/authentication.md
+++ b/docs/content/guide/authentication.md
@@ -4,13 +4,15 @@ description = "API key, credentials, hybrid, and cloud auth modes explained"
 weight = 4
 +++
 
-Unifly supports three authentication modes. The right choice depends on whether you need live WebSocket streams.
+Unifly supports four authentication modes. The right choice depends on whether you need live WebSocket streams, and whether you reach the controller directly or through Ubiquiti's cloud.
 
 ## Which Mode Do I Need?
 
 {% mermaid() %}
 flowchart TD
-START["What do you need?"] --> Q1{"Live event streaming<br/>(events watch or TUI)?"}
+START["What do you need?"] --> Q0{"Direct connection<br/>to the controller?"}
+Q0 -->|"No, via Ubiquiti cloud"| CLOUD["Cloud Mode"]
+Q0 -->|"Yes"| Q1{"Live event streaming<br/>(events watch or TUI)?"}
 Q1 -->|"No"| APIKEY["API Key Mode"]
 Q1 -->|"Yes"| HYBRID["Hybrid Mode"]
 Q1 -->|"No API key<br/>available"| SESSION["Username/Password Mode"]
@@ -18,6 +20,7 @@ Q1 -->|"No API key<br/>available"| SESSION["Username/Password Mode"]
     style APIKEY fill:#50fa7b,color:#0a0a0f
     style HYBRID fill:#80ffea,color:#0a0a0f
     style SESSION fill:#f1fa8c,color:#0a0a0f
+    style CLOUD fill:#ff6ac1,color:#0a0a0f
 
 {% end %}
 
@@ -78,9 +81,25 @@ How it works: unifly uses the API key for every HTTP request and the cookie sess
 
 To verify Hybrid is working, run `unifly events watch` — if events stream, the WebSocket cookie session is active.
 
+## Cloud Mode
+
+Cloud mode reaches your controllers through Ubiquiti's [Site Manager](https://unifi.ui.com) instead of a direct network connection. It needs two things: a **Site Manager API key** (created under your Ubiquiti account, not on the controller) and a **console ID** (`host_id`) naming which console to talk to.
+
+```bash
+unifly config cloud-setup              # Guided setup: validates the key,
+                                       # picks a console and site, writes the profile
+```
+
+Two distinct surfaces run on this key:
+
+- **Fleet queries** (`unifly cloud hosts|sites|devices|isp|sdwan`) talk to the Site Manager fleet API directly and need no `host_id` at all.
+- **Connector-routed commands**: with `auth_mode = "cloud"`, regular Integration-backed commands (`networks list`, `wifi create`, `firewall policies list`, ...) tunnel through the cloud connector to the console named by `host_id`. When the API key sees exactly one console (or exactly one you own), unifly resolves `host_id` automatically; otherwise set it in the profile or pass `--host-id`.
+
+Session-backed commands (`events watch`, `stats`, device commands, admin) are not reachable through the connector and still require direct controller access. The full walkthrough lives on the [Cloud & Site Manager page](/guide/cloud).
+
 ## Credential Storage
 
-All credentials are stored in your OS keyring:
+Credentials go in your OS keyring by default:
 
 | OS      | Backend                                 |
 | ------- | --------------------------------------- |
@@ -89,6 +108,8 @@ All credentials are stored in your OS keyring:
 | Windows | Windows Credential Manager              |
 
 The `config.toml` file stores non-sensitive settings like controller URLs and site names. The setup wizard offers keyring storage by default, but also provides a plaintext config fallback for environments where the keyring isn't available (headless servers, WSL, CI).
+
+Secrets resolve in a fixed order: an environment variable named by `api_key_env` (or `UNIFI_PASSWORD` for passwords), then an explicit `api_key = "..."` / `password = "..."` value in `config.toml`, then the keyring. **Explicit config beats the keyring**, so editing a plaintext value in `config.toml` is never silently overridden by a stale keyring entry from an earlier `config init`.
 
 To update a stored password:
 

--- a/docs/content/guide/cloud.md
+++ b/docs/content/guide/cloud.md
@@ -1,0 +1,103 @@
++++
+title = "Cloud & Site Manager"
+description = "Fleet queries and connector-routed control through Ubiquiti's cloud"
+weight = 5
++++
+
+Unifly speaks Ubiquiti's [Site Manager](https://unifi.ui.com) cloud API. One Site Manager API key unlocks two distinct surfaces: **fleet queries** across every console your account can see, and a **cloud connector** that routes normal Integration commands to a console you have no direct network path to.
+
+{% mermaid() %}
+graph LR
+UNIFLY["unifly"] --> FLEET["Fleet API<br/><i>api.ui.com/v1</i>"]
+UNIFLY --> CONN["Cloud Connector<br/><i>/v1/connector/consoles/{host_id}</i>"]
+FLEET --> ALL["All consoles:<br/>hosts, sites, devices, ISP, SD-WAN"]
+CONN --> ONE["One console:<br/>Integration API commands"]
+
+    style FLEET fill:#80ffea,color:#0a0a0f
+    style CONN fill:#ff6ac1,color:#0a0a0f
+
+{% end %}
+
+## Setup
+
+Create a Site Manager API key under your Ubiquiti account (not on a controller), then run the guided wizard:
+
+```bash
+unifly config cloud-setup
+```
+
+The wizard validates the key against the fleet API, lists the consoles the key can see, lets you pick a console and a site, and writes a profile with `auth_mode = "cloud"` and the chosen console's `host_id`. The key itself lands wherever you choose in the wizard: the OS keyring (default), a named environment variable (`api_key_env`), or plaintext in the config.
+
+```toml
+[profiles.cloud]
+auth_mode = "cloud"
+host_id = "ABC123..."       # The chosen console
+site = "default"
+# API key in the OS keyring, or via api_key_env
+```
+
+Cloud traffic goes to `api.ui.com` over normal public TLS; the `insecure` and `ca_cert` settings do not apply.
+
+## Fleet Queries
+
+The `cloud` command group hits the fleet API directly. No controller connection, no `host_id` needed:
+
+```bash
+unifly cloud hosts                      # Consoles the key can see
+unifly cloud hosts get <ID>             # One console in detail
+unifly cloud sites                      # Sites across the whole fleet
+unifly cloud devices                    # Devices across every console
+unifly cloud devices --host <ID>        # Scope to one console (repeatable)
+unifly cloud isp                        # ISP metrics
+unifly cloud isp --type 5m              # Higher resolution
+unifly cloud isp query --sites site-a,site-b
+unifly cloud sdwan                      # SD-WAN configs
+unifly cloud sdwan get <ID>
+unifly cloud sdwan status <ID>
+```
+
+These work from any machine with internet access, which makes them handy for cross-controller health snapshots and fleet dashboards.
+
+## Connector-Routed Commands
+
+With `auth_mode = "cloud"`, the regular Integration-backed commands transparently tunnel through the connector to the console named by `host_id`:
+
+```bash
+unifly -p cloud networks list
+unifly -p cloud firewall policies list
+unifly -p cloud wifi create --name "Guest" --network <ID> ...
+```
+
+### How `host_id` Resolves
+
+The console ID comes from, in order: the `--host-id` flag (or `UNIFI_HOST_ID`), the profile's `host_id_env` variable, then the profile's `host_id` value. When none of those are set, unifly asks the fleet API and auto-resolves:
+
+- The key sees exactly **one console**: that console is used.
+- The key sees several, but you **own exactly one**: the owned console is used.
+- Otherwise the command errors and lists the available consoles; pin one with `unifly config set host_id <ID>` or `--host-id`.
+
+### Switching Sites
+
+`cloud switch` repoints the active cloud profile at another site on the console, accepting a site name, internal reference, or UUID:
+
+```bash
+unifly cloud switch "Branch Office"
+```
+
+## What Stays Session-Only
+
+The connector proxies the Integration API only. Session-backed features need a direct connection to the controller and do not work in cloud mode:
+
+- `events list` / `events watch` and the TUI's live event stream
+- `stats` (historical reports) and DPI status/control
+- Device commands (`restart`, `adopt`, `locate`, `upgrade`, `speedtest`, ...)
+- Switch port configuration, firewall groups, NAT, site settings, and the Session-backed VPN surface
+- Admin management and backups
+
+For those, use a direct profile (`integration`, `session`, or `hybrid`) when you're on a network that can reach the controller. Profiles switch per-command with `-p`, so a cloud profile and a direct profile for the same console coexist cleanly.
+
+## Next Steps
+
+- [Authentication](/guide/authentication): how cloud mode fits next to the other three modes
+- [CLI Commands](/reference/cli): the condensed cloud command list
+- [Troubleshooting](/troubleshooting): host_id ambiguity and permission-scoped keys

--- a/docs/content/guide/configuration.md
+++ b/docs/content/guide/configuration.md
@@ -58,6 +58,7 @@ default_profile = "home"
 output = "table"
 color = "auto"
 timeout = 30
+insecure = false
 
 [profiles.home]
 controller = "https://192.168.1.1"
@@ -83,18 +84,21 @@ timeout = 45
 
 ### Profile Settings Reference
 
-| Setting       | Values                             | Description                                                                                                |
-| ------------- | ---------------------------------- | ---------------------------------------------------------------------------------------------------------- |
-| `controller`  | URL                                | Controller address (include port if non-standard)                                                          |
-| `site`        | string                             | Site name or UUID. Default: `default`                                                                      |
-| `auth_mode`   | `integration`, `session`, `hybrid` | Which APIs to authenticate against. `"legacy"` is accepted as a backwards-compatible alias for `"session"` |
-| `username`    | string                             | Session/Hybrid login username                                                                              |
-| `api_key`     | string                             | Integration API key (prefer `api_key_env`)                                                                 |
-| `api_key_env` | string                             | Env var name containing the API key                                                                        |
-| `totp_env`    | string                             | Env var name for MFA one-time password                                                                     |
-| `insecure`    | bool                               | Accept self-signed TLS certificates                                                                        |
-| `ca_cert`     | path                               | Custom CA certificate PEM file                                                                             |
-| `timeout`     | seconds                            | Request timeout (default: 30)                                                                              |
+| Setting       | Values                                      | Description                                                                                                |
+| ------------- | ------------------------------------------- | ---------------------------------------------------------------------------------------------------------- |
+| `controller`  | URL                                         | Controller address (include port if non-standard)                                                          |
+| `site`        | string                                      | Site name or UUID. Default: `default`                                                                      |
+| `auth_mode`   | `integration`, `session`, `hybrid`, `cloud` | Which APIs to authenticate against. `"legacy"` is accepted as a backwards-compatible alias for `"session"` |
+| `username`    | string                                      | Session/Hybrid login username                                                                              |
+| `password`    | string                                      | Session/Hybrid password in plaintext (prefer the keyring via `config set-password`)                        |
+| `api_key`     | string                                      | Integration API key (prefer `api_key_env`)                                                                 |
+| `api_key_env` | string                                      | Env var name containing the API key                                                                        |
+| `host_id`     | string                                      | Site Manager console ID for cloud mode                                                                     |
+| `host_id_env` | string                                      | Env var name containing the console ID                                                                     |
+| `totp_env`    | string                                      | Env var name for MFA one-time password                                                                     |
+| `insecure`    | bool                                        | Accept self-signed TLS certificates                                                                        |
+| `ca_cert`     | path                                        | Custom CA certificate PEM file                                                                             |
+| `timeout`     | seconds                                     | Request timeout (default: 30)                                                                              |
 
 {% tip() %}
 Use `api_key_env` instead of `api_key` to avoid putting secrets in the config file. The API key is read from the named environment variable at runtime.
@@ -104,7 +108,7 @@ Use `api_key_env` instead of `api_key` to avoid putting secrets in the config fi
 
 `unifly config set <key> <value>` supports these keys:
 
-`controller`, `site`, `auth_mode`, `api_key`, `api_key_env`, `username`, `insecure`, `timeout`, `ca_cert`
+`controller`, `site`, `auth_mode`, `api_key`, `api_key_env`, `host_id`, `host_id_env`, `username`, `insecure`, `timeout`, `ca_cert`
 
 ```bash
 unifly config set auth_mode hybrid
@@ -132,6 +136,8 @@ All settings can be overridden via environment variables. Useful for CI/CD, scri
 | `UNIFI_INSECURE` | `1` to accept self-signed certs       |
 | `UNIFI_TIMEOUT`  | Request timeout in seconds            |
 | `UNIFI_TOTP`     | One-time password for MFA controllers |
+| `UNIFI_HOST_ID`  | Site Manager console ID (cloud mode)  |
+| `UNIFI_DEMO`     | `1` to sanitize PII in output         |
 | `NO_COLOR`       | Disable colored output (standard)     |
 
 ### Example: CI/CD Pipeline
@@ -165,6 +171,11 @@ A["1. CLI Flags"] --> B["2. Environment Vars"] --> C["3. Profile Config"] --> D[
 3. **Profile config** (`[profiles.home]` section in config.toml)
 4. **Default values** (`[defaults]` section, then built-in defaults)
 
+Two settings deserve a closer look:
+
+- **Timeout** resolves flag/env, then the profile's `timeout`, then `[defaults].timeout`, then the built-in 30 seconds.
+- **TLS** follows a ladder: an explicit `insecure = true` (flag, env, or profile) skips verification; otherwise a profile `ca_cert` wins, **including over `[defaults].insecure = true`** (a configured CA is still verification); otherwise `[defaults].insecure` decides. Passing `--insecure=false` forces verification no matter what the config says (the explicit value requires the equals form).
+
 ## Global Flags
 
 These flags work with every command:
@@ -174,13 +185,14 @@ These flags work with every command:
 -c, --controller <URL>   Controller URL (overrides profile)
 -s, --site <SITE>        Site name or UUID
 -o, --output <FORMAT>    Output: table, json, json-compact, yaml, plain
--k, --insecure           Accept self-signed TLS certificates
+-k, --insecure           Accept self-signed TLS certs (--insecure=false forces verification)
 -v, --verbose            Increase verbosity (-v, -vv, -vvv)
 -q, --quiet              Suppress non-error output
 -y, --yes                Skip confirmation prompts
-    --timeout <SECS>     Request timeout (default: 30)
+    --timeout <SECS>     Request timeout (default 30, profiles may override)
     --color <MODE>       Color: auto, always, never
     --no-cache           Force fresh login (bypass session cache)
+    --api-key <KEY>      Integration API key (one-shot override)
 ```
 
 ## TLS Certificates

--- a/docs/content/guide/quick-start.md
+++ b/docs/content/guide/quick-start.md
@@ -21,10 +21,17 @@ unifly config init
 The wizard walks you through:
 
 1. **Controller URL**: your controller's address (e.g., `https://192.168.1.1`)
-2. **Authentication**: API key, username/password, or hybrid mode
-3. **Site selection**: choose which site to manage
+2. **TLS**: whether the controller uses a self-signed certificate (the default on UniFi hardware; the wizard pre-selects the right answer for LAN addresses)
+3. **Authentication**: API key, username/password, or hybrid mode
+4. **Site selection**: choose which site to manage
 
 Credentials are stored in your OS keyring by default. A plaintext config fallback is available if the keyring isn't accessible.
+
+For a cloud profile that reaches your controllers through Ubiquiti's Site Manager instead of a direct connection, run the guided cloud wizard (see [Cloud & Site Manager](/guide/cloud)):
+
+```bash
+unifly config cloud-setup
+```
 
 ## First Commands
 
@@ -75,6 +82,13 @@ unifly clients list -o plain | xargs -n1 unifly clients get
 
 {% end %}
 
+Create commands print the created entity on stdout in the requested format (the human confirmation goes to stderr), so capturing a new ID for the next step is a one-liner:
+
+```bash
+NET_ID=$(unifly networks create --name "IoT" --vlan 30 \
+  --management gateway --ipv4-host "10.0.30.1/24" -o json | jq -r '.id')
+```
+
 ## Launch the TUI
 
 For real-time monitoring, launch the terminal dashboard:
@@ -96,7 +110,7 @@ graph LR
 8 --> 9["9 WiFi<br/><i>RF health & roaming</i>"]
 {% end %}
 
-Navigate screens with number keys `1`-`9`. Press `,` for settings, `?` for help, `q` to quit.
+Eleven screens in total: the nine above on number keys `1`-`9`, a Settings screen on `,` (profiles, themes, display options), and an Onboarding wizard that appears automatically on first launch. Press `?` for help, `q` to quit.
 
 {% tip(title="Heads Up") %}
 

--- a/docs/content/guide/settings.md
+++ b/docs/content/guide/settings.md
@@ -51,11 +51,14 @@ Settings sections control controller-wide behavior — IPS modes, management acc
 
 ## Exporting Everything
 
-`settings export` dumps every section as raw JSON, regardless of the `--output` flag. It pairs well with version control for change tracking, or with `jq` for one-off questions:
+`settings export` dumps every section as raw JSON, regardless of the `--output` flag — **including `x_`-prefixed credential fields that the table view masks**. Treat the output as secret material: never commit it to version control as-is. Strip the sensitive fields first if you want change tracking:
 
 ```bash
-unifly settings export > settings-$(date +%F).json
+# One-off inspection
 unifly settings export | jq '.[] | select(.key == "ips")'
+
+# Sanitized snapshot safe for change tracking
+unifly settings export | jq 'walk(if type == "object" then with_entries(select(.key | startswith("x_") | not)) else . end)' > settings-$(date +%F).json
 ```
 
 ## Relationship to Other Commands

--- a/docs/content/guide/settings.md
+++ b/docs/content/guide/settings.md
@@ -1,0 +1,69 @@
++++
+title = "Site Settings"
+description = "Read and write every site-level settings section from the terminal"
+weight = 8
++++
+
+The `unifly settings` command reads and writes site-level settings: the same sections the controller web UI scatters across its Settings screens (management, DPI, IPS, guest access, radio AI, and the rest). Every subcommand talks to the Session API, so an API key on UniFi OS or session credentials is required.
+
+```bash
+unifly settings list                 # Summary of every settings section
+unifly settings get <KEY>            # One section in full
+unifly settings set <KEY> <FIELD> <VALUE>
+unifly settings set <KEY> --data '{"field": "value"}'
+unifly settings export               # Raw JSON dump of everything
+```
+
+## Discovering Sections
+
+`settings list` shows a summary table of all sections with their key, field count, enabled status, and notable values. Keys are the controller's internal section names: `mgmt`, `dpi`, `ips`, `usg`, `radio_ai`, `guest_access`, and so on.
+
+```bash
+unifly settings list
+unifly settings get dpi
+unifly settings get ips -o json
+```
+
+{% tip() %}
+In table mode, `get` masks fields prefixed with `x_` — those hold credentials and internal secrets. Use `-o json` to see the real values when you actually need them.
+{% end %}
+
+## Writing a Field
+
+`set` performs a read-modify-write: it fetches the current section, patches the one field you named, and PUTs the full section back. Values are parsed as booleans (`true`/`false`), then numbers, then fall back to strings.
+
+```bash
+unifly settings set dpi enabled true
+unifly settings set mgmt advanced_feature_enabled false
+```
+
+For multiple fields at once, `--data` merges a JSON object into the section instead of a single field/value pair (the two forms are mutually exclusive):
+
+```bash
+unifly settings set usg --data '{"mss_clamp": "auto", "broadcast_ping": false}'
+```
+
+Because the PUT replaces the entire section, unifly strips the `_id`, `site_id`, and `key` metadata fields before sending, so the payload round-trips cleanly.
+
+{% warning() %}
+Settings sections control controller-wide behavior — IPS modes, management access, guest portals. A wrong value can lock you out of a surface or disrupt clients. Read the section with `get` first, and prefer patching single fields over replaying large `--data` blobs.
+{% end %}
+
+## Exporting Everything
+
+`settings export` dumps every section as raw JSON, regardless of the `--output` flag. It pairs well with version control for change tracking, or with `jq` for one-off questions:
+
+```bash
+unifly settings export > settings-$(date +%F).json
+unifly settings export | jq '.[] | select(.key == "ips")'
+```
+
+## Relationship to Other Commands
+
+Some commands are curated fronts over the same settings machinery: `dpi status|enable|disable` toggles the `dpi` section, and [`vpn settings`](/guide/vpn#magic-site-to-site-and-settings) manages the VPN-related sections with friendlier names. `settings` is the general-purpose surface for everything else.
+
+## Next Steps
+
+- [CLI Commands](/reference/cli): the condensed settings command list
+- [Authentication](/guide/authentication): session gating explained
+- [VPN](/guide/vpn): the VPN-specific settings front-end

--- a/docs/content/guide/switch-ports.md
+++ b/docs/content/guide/switch-ports.md
@@ -110,7 +110,13 @@ With `--with-clients`, the export prepends a comment line above each port record
 }
 ```
 
-Commit the export to git and re-export on a schedule: `git diff` then shows exactly which port's occupant changed, which is a cheap way to catch moved cables, swapped APs, or surprise devices.
+Commit the export to git and re-export on a schedule to catch moved cables, swapped APs, or surprise devices. Every export stamps a fresh timestamp into each `// last-seen` marker, so strip the timestamps before diffing to see only real occupant changes:
+
+```bash
+unifly devices ports-export <mac> --with-clients \
+  | sed -E 's|// last-seen [^:]+: |// occupant: |' > ports/<mac>.jsonc
+git diff ports/<mac>.jsonc
+```
 
 {% tip() %}
 The `// last-seen ` prefix (with a single trailing space) is a stable parse anchor if you script against the export.

--- a/docs/content/guide/switch-ports.md
+++ b/docs/content/guide/switch-ports.md
@@ -1,0 +1,127 @@
++++
+title = "Switch Ports"
+description = "Switch port profiles as reviewable JSONC files: export, edit, apply, diff"
+weight = 7
++++
+
+Switch port configuration is a config-as-code surface: export a switch's port overrides to a JSONC file, keep it in git, edit it in review, and apply it back. Three commands make the loop:
+
+```bash
+unifly devices ports <SWITCH>              # Read current port config
+unifly devices ports-export <SWITCH>       # Export overrides as JSONC
+unifly devices port-set <SWITCH> -F ports.jsonc   # Apply a file
+```
+
+`<SWITCH>` accepts a device ID or MAC. Port indices are **1-based** throughout, matching the labels on the hardware and the controller's wire format.
+
+## Reading Ports
+
+```bash
+unifly devices ports <SWITCH>                   # Table of ports and overrides
+unifly devices ports <SWITCH> --with-clients    # Annotate with what's plugged in
+unifly devices ports <SWITCH> -o json           # Full structured output
+```
+
+`--with-clients` adds a connections column counting the end-user clients and adopted devices (APs, downstream switches) observed on each port; JSON output carries a `connections` array with `kind`, `mac`, `name`, and, for clients, `ip` and `vlan_id`.
+
+## Quick Single-Port Changes
+
+For one-off tweaks, `port-set` takes the port index and flags directly:
+
+```bash
+unifly devices port-set <SWITCH> 9 --mode access --native-vlan IoT
+unifly devices port-set <SWITCH> 1 --mode trunk --tagged-vlans "Infra,IoT,Cameras"
+unifly devices port-set <SWITCH> 5 --name "camera-ne" --poe auto
+unifly devices port-set <SWITCH> 3 --speed 2500
+unifly devices port-set <SWITCH> 7 --reset      # Back to controller defaults
+```
+
+- `--native-vlan` and `--tagged-vlans` accept network **names** or IDs. Names are resolved against the controller's network list, and an ambiguous name errors out rather than picking one.
+- `--mode trunk` without `--tagged-vlans` trunks **all** VLANs; passing an explicit list switches the port to a custom tagged set.
+- `--poe` accepts `off`, `auto`, `pasv24`, and `passthrough`. There is no `on`: `auto` is the on/negotiate mode.
+- `--speed auto` re-enables auto-negotiation; the numeric values pin a link speed.
+- `--reset` removes the port's override entirely, returning it to controller defaults. It prompts for confirmation unless `-y` is passed.
+
+## The JSONC Payload
+
+`port-set -F` applies a JSONC file (comments and trailing commas are allowed) describing one or more ports on a single device:
+
+```jsonc
+{
+  "ports": [
+    // Trunk uplink carrying all VLANs
+    {
+      "index": 1,
+      "name": "uplink",
+      "mode": "trunk",
+      "native_vlan": "Infra",
+      "tagged_all": true,
+      "poe": "off",
+    },
+
+    // Access port pinned to one VLAN
+    {
+      "index": 9,
+      "name": "mac-mini",
+      "mode": "access",
+      "native_vlan": "Personal",
+      "poe": "auto",
+    },
+
+    // Clear a stale override
+    { "index": 7, "reset": true },
+  ],
+}
+```
+
+Per-port fields: `name`, `mode` (`access` / `trunk` / `mirror`), `native_network_id` (alias `native_vlan`), `tagged_network_ids` (alias `tagged_vlans`), `tagged_all`, `poe`, `speed`, and `reset`. Unknown fields are rejected with an error, so typos surface instead of silently disappearing.
+
+### Splice Semantics
+
+The payload is a splice, not a replacement:
+
+- Ports **not listed** keep their existing override untouched.
+- A listed port **merges** the given fields into its override; omitted fields are unchanged.
+- An **empty** `tagged_network_ids: []` clears the tagged list (JSON Merge Patch style); omitting the field leaves it alone.
+- `"reset": true` removes that port's override entry entirely.
+
+This means a payload file can safely describe just the ports you care about, and applying it twice is idempotent.
+
+## Export and Drift Detection
+
+`ports-export` emits the device's current configuration in exactly the shape `port-set -F` accepts:
+
+```bash
+unifly devices ports-export <SWITCH> > ports.jsonc         # Only ports with overrides
+unifly devices ports-export <SWITCH> --all > ports.jsonc   # Every port
+unifly devices ports-export <SWITCH> --with-clients > ports.jsonc
+```
+
+The round-trip is non-destructive: export, then re-apply the same file, and the device configuration is unchanged.
+
+With `--with-clients`, the export prepends a comment line above each port recording what was observed on it:
+
+```jsonc
+// last-seen 2026-08-05T17:20:00Z: aa:bb:cc:dd:ee:01 (Living Room AP, device)
+{
+  "index": 3,
+  "name": "ap-living-room",
+  ...
+}
+```
+
+Commit the export to git and re-export on a schedule: `git diff` then shows exactly which port's occupant changed, which is a cheap way to catch moved cables, swapped APs, or surprise devices.
+
+{% tip() %}
+The `// last-seen ` prefix (with a single trailing space) is a stable parse anchor if you script against the export.
+{% end %}
+
+## Authentication
+
+Port configuration lives on Session API routes; the Integration API does not expose port VLAN settings. On UniFi OS consoles an Integration API key satisfies these routes, so no username or password is needed. Classic standalone controllers require `auth_mode = "session"` or `"hybrid"`.
+
+## Next Steps
+
+- [CLI Commands](/reference/cli): the condensed switch-port command list
+- [Networks](/reference/cli#networks): the VLANs your port profiles reference
+- [Troubleshooting](/troubleshooting): auth-mode errors and fixes

--- a/docs/content/guide/vpn.md
+++ b/docs/content/guide/vpn.md
@@ -1,0 +1,162 @@
++++
+title = "VPN"
+description = "Site-to-site tunnels, remote access, WireGuard peers, and VPN settings from the CLI"
+weight = 6
++++
+
+Unifly manages the full UniFi VPN surface: site-to-site tunnels, remote-access servers, WireGuard peers, client VPN profiles, live connections, and the site-level VPN feature toggles. The read-only inventory rides the Integration API; everything else is Session-backed, so an API key on UniFi OS or session credentials unlocks the whole surface.
+
+{% mermaid() %}
+graph LR
+subgraph "Integration API"
+SRV["vpn servers"]
+TUN["vpn tunnels"]
+end
+
+    subgraph "Session API"
+        S2S["vpn site-to-site"]
+        RA["vpn remote-access"]
+        CL["vpn clients"]
+        SET["vpn settings"]
+    end
+
+    subgraph "Session v2 API"
+        CONN["vpn connections"]
+        PEERS["vpn peers"]
+        MAGIC["vpn magic-site-to-site"]
+    end
+
+    style SRV fill:#80ffea,color:#0a0a0f
+    style TUN fill:#80ffea,color:#0a0a0f
+    style S2S fill:#50fa7b,color:#0a0a0f
+    style RA fill:#50fa7b,color:#0a0a0f
+
+{% end %}
+
+## Inventory and Health
+
+Start with the read-only views to see what exists:
+
+```bash
+unifly vpn servers                    # VPN servers (Integration API)
+unifly vpn tunnels                    # Site-to-site tunnel inventory (Integration API)
+unifly vpn status                     # Live IPsec tunnel status (security associations)
+unifly vpn health                     # VPN subsystem health
+```
+
+## Site-to-Site Tunnels
+
+Site-to-site records are payload-driven: `create` and `update` take a JSON file via `--from-file` / `-F` rather than a wall of flags.
+
+```bash
+unifly vpn site-to-site list
+unifly vpn site-to-site get <ID>
+unifly vpn site-to-site create -F ipsec.json
+unifly vpn site-to-site update <ID> -F ipsec.json
+unifly vpn site-to-site delete <ID>
+```
+
+A minimal IPsec payload names the peer, the pre-shared key, and the remote subnets:
+
+```json
+{
+  "name": "Branch Office Tunnel",
+  "vpn_type": "ipsec-vpn",
+  "enabled": true,
+  "x_ipsec_pre_shared_key": "REPLACE_ME",
+  "ipsec_peer_ip": "203.0.113.42",
+  "ipsec_key_exchange": "ikev2",
+  "remote_vpn_subnets": ["10.20.0.0/24"]
+}
+```
+
+The [examples/](https://github.com/hyperb1iss/unifly/tree/main/skills/unifly/examples) directory in the repository has complete templates with the full cipher configuration.
+
+## Remote Access
+
+Remote-access servers (WireGuard, OpenVPN, Teleport) follow the same payload-driven CRUD, plus two OpenVPN helpers:
+
+```bash
+unifly vpn remote-access list
+unifly vpn remote-access get <ID>
+unifly vpn remote-access create -F wireguard.json
+unifly vpn remote-access update <ID> -F wireguard.json
+unifly vpn remote-access delete <ID>
+
+unifly vpn remote-access suggest-port              # Free ports for a new OpenVPN server
+unifly vpn remote-access download-config <ID>      # Export an .ovpn client config
+```
+
+`download-config` writes `<ID>.ovpn` in the current directory by default; pass `--path` to choose another location.
+
+## WireGuard Peers
+
+Peers hang off a remote-access server, so every mutation takes the parent server ID first:
+
+```bash
+unifly vpn peers list                        # All peers, every server
+unifly vpn peers list <SERVER_ID>            # Scoped to one server
+unifly vpn peers get <SERVER_ID> <ID>
+unifly vpn peers create <SERVER_ID> -F peer.json
+unifly vpn peers update <SERVER_ID> <ID> -F peer.json
+unifly vpn peers delete <SERVER_ID> <ID>
+unifly vpn peers subnets                     # Subnets already consumed by peers
+```
+
+A peer payload is small: a name, the client's public key, and its tunnel address.
+
+```json
+{
+  "name": "Bliss Laptop",
+  "interface_ip": "10.255.0.2",
+  "public_key": "REPLACE_WITH_CLIENT_PUBLIC_KEY",
+  "allowed_ips": ["10.255.0.2/32"]
+}
+```
+
+Run `peers subnets` before assigning addresses to avoid colliding with an existing peer.
+
+## Client VPNs and Connections
+
+Client VPN profiles make the gateway dial out to another provider. Live connections are a separate, restartable inventory:
+
+```bash
+unifly vpn clients list                      # Configured client VPN profiles
+unifly vpn clients create -F client.json
+unifly vpn clients update <ID> -F client.json
+unifly vpn clients delete <ID>
+
+unifly vpn connections list                  # Active VPN client connections
+unifly vpn connections get <ID>
+unifly vpn connections restart <ID>          # Bounce one connection
+```
+
+## Magic Site-to-Site and Settings
+
+Magic site-to-site (Ubiquiti's auto-configured mesh between consoles) is read-only; site-level VPN toggles are read-write:
+
+```bash
+unifly vpn magic-site-to-site list
+unifly vpn magic-site-to-site get <ID>
+
+unifly vpn settings list                     # Teleport, OpenVPN, peer-to-peer, ...
+unifly vpn settings get teleport
+unifly vpn settings set teleport --enabled true
+unifly vpn settings patch peer-to-peer -F payload.json
+```
+
+`settings patch` accepts either a raw session setting body or the wrapper shape emitted by `settings get` (`{"key": ..., "enabled": ..., "fields": {...}}`), so a get-edit-patch round-trip works without reshaping.
+
+{% warning(title="Secrets Are Redacted") %}
+WireGuard private keys, IPsec pre-shared keys, and similar sensitive material are redacted in both `get` and `create` output. When you build an update payload from a `get`, reconstruct those fields explicitly if the controller requires them unchanged; a redacted placeholder is not a valid value.
+{% end %}
+
+## Authentication
+
+`vpn servers` and `vpn tunnels` need the Integration API (an API key). Every other subcommand is Session-backed: an API key works on UniFi OS consoles, while classic standalone controllers need `auth_mode = "session"` or `"hybrid"` with credentials. Cloud-connector profiles cannot reach the Session-backed VPN surface.
+
+## Next Steps
+
+- [CLI Commands](/reference/cli): the condensed VPN command list with gotchas
+- [Authentication](/guide/authentication): which auth mode enables which commands
+- [Site Settings](/guide/settings): the general settings machinery behind `vpn settings`

--- a/docs/content/reference/cli.md
+++ b/docs/content/reference/cli.md
@@ -329,6 +329,8 @@ unifly system poweroff                          # Power off hardware (UDM only)
 ```bash
 unifly vpn servers                              # List VPN servers (Integration)
 unifly vpn tunnels                              # List site-to-site tunnels (Integration)
+unifly vpn status                               # Live IPsec tunnel status
+unifly vpn health                               # VPN subsystem health
 unifly vpn site-to-site list                    # List site-to-site VPN records
 unifly vpn site-to-site get <ID>                # Inspect one site-to-site VPN record
 unifly vpn site-to-site create -F vpn.json      # Create a site-to-site VPN

--- a/docs/content/reference/cli.md
+++ b/docs/content/reference/cli.md
@@ -6,7 +6,7 @@ weight = 1
 
 Every command supports `--help` for exhaustive flag listings. This page documents subcommands, key flags, and gotchas you won't find in `--help`.
 
-**API legend:** **I** = Integration API (API key). **L** = Session API (username/password). **H** = Works in any mode, enriched by Hybrid.
+**API legend:** **I** = Integration API (API key). **L** = Session API (API key on UniFi OS, or username/password). **H** = Works in any mode, enriched when session HTTP access exists.
 
 ## Commands
 
@@ -16,7 +16,7 @@ Every command supports `--help` for exhaustive flag listings. This page document
 | `clients`       | `cl`       | H     | Manage connected clients and DHCP reservations                                                                                                                               |
 | `networks`      | `net`, `n` | I     | Manage networks and VLANs                                                                                                                                                    |
 | `wifi`          | `w`        | I     | Manage WiFi broadcasts (SSIDs)                                                                                                                                               |
-| `firewall`      | `fw`       | I     | Manage firewall policies and zones                                                                                                                                           |
+| `firewall`      | `fw`       | Mixed | Manage firewall policies, zones, and groups                                                                                                                                  |
 | `nat`           |            | L     | Manage NAT policies (masquerade, SNAT, DNAT)                                                                                                                                 |
 | `acl`           |            | I     | Manage ACL rules                                                                                                                                                             |
 | `dns`           |            | I     | Manage DNS policies (local records)                                                                                                                                          |
@@ -29,11 +29,13 @@ Every command supports `--help` for exhaustive flag listings. This page document
 | `sites`         |            | L     | Manage sites                                                                                                                                                                 |
 | `admin`         |            | L     | Administrator management                                                                                                                                                     |
 | `system`        | `sys`      | Mixed | System operations and info                                                                                                                                                   |
+| `settings`      |            | L     | Read and write site-level settings sections                                                                                                                                  |
 | `topology`      | `topo`     | H     | Show network topology tree                                                                                                                                                   |
 | `dpi`           |            | Mixed | DPI reference data and control                                                                                                                                               |
 | `radius`        |            | I     | View RADIUS profiles                                                                                                                                                         |
 | `wans`          |            | I     | View WAN interfaces                                                                                                                                                          |
 | `countries`     |            | I     | List available country codes                                                                                                                                                 |
+| `cloud`         |            | Cloud | Query the Site Manager fleet (consoles, sites, devices, ISP, SD-WAN)                                                                                                         |
 | `config`        |            | Local | Manage CLI configuration                                                                                                                                                     |
 | `completions`   |            | Local | Generate shell completions                                                                                                                                                   |
 | `api`           |            | L     | Raw API passthrough (GET/POST/PUT/PATCH/DELETE any endpoint)                                                                                                                 |
@@ -47,7 +49,7 @@ List commands default to 25 rows. Pass `--all` or `--limit 200` for complete res
 
 ```bash
 unifly devices list                             # All adopted devices
-unifly devices list --filter "state.eq('ONLINE')"  # Filter by status
+unifly devices list --filter "state.eq('Online')"  # Filter by status
 unifly devices get <ID|MAC>                     # Device details
 unifly devices pending                          # Devices awaiting adoption
 unifly devices adopt <MAC>                      # Adopt a pending device
@@ -62,7 +64,21 @@ unifly devices speedtest                        # WAN speed test (gateway only)
 unifly devices tags                             # List device tags
 ```
 
-Gotchas: `restart`, `locate`, `upgrade`, `provision`, `speedtest`, and `port-cycle` require Session API access. `list` and `get` work with any auth mode but return richer data in Hybrid (client count, uplink MAC).
+Gotchas: `restart`, `locate`, `upgrade`, `provision`, `speedtest`, and `port-cycle` require Session API access. `list` and `get` work with any auth mode but return richer data when session HTTP access exists (client count, uplink MAC).
+
+### Switch Ports (config-as-code)
+
+```bash
+unifly devices ports <ID|MAC>                   # Current port config
+unifly devices ports <ID|MAC> --with-clients    # Annotate with connected clients
+unifly devices ports-export <ID|MAC>            # Export overrides as JSONC
+unifly devices ports-export <ID|MAC> --all      # Include every port
+unifly devices port-set <ID|MAC> 5 --mode access --native-vlan IoT
+unifly devices port-set <ID|MAC> -F ports.jsonc # Apply a JSONC file
+unifly devices port-set <ID|MAC> 5 --reset      # Back to controller defaults
+```
+
+Port indices are **1-based**, matching the controller's wire format. `port-set -F` accepts a JSONC payload (comments and trailing commas allowed) with splice semantics: ports not listed keep their existing override, and a per-port `"reset": true` removes that port's override entirely. `--with-clients` adds connection annotations, and on `ports-export` it prepends `// last-seen <timestamp>: <mac>` comment lines for git-diff drift detection. See [Switch Ports](/guide/switch-ports) for the full workflow and payload schema.
 
 ## Clients
 
@@ -147,6 +163,20 @@ unifly firewall zones update <ID> --networks <ID1,ID2>
 unifly firewall zones delete <ID>
 ```
 
+### Groups
+
+```bash
+unifly firewall groups list
+unifly firewall groups list --type port-group
+unifly firewall groups get <ID>
+unifly firewall groups create --name "Web Ports" --type port-group --members "80,443,8000-8002"
+unifly firewall groups create --name "IoT Nets" --type address-group --members "10.0.30.0/24"
+unifly firewall groups update <ID> --members "80,443"
+unifly firewall groups delete <ID>
+```
+
+Gotchas: groups use the **Session API** (`rest/firewallgroup`), not Integration; an API key on UniFi OS is sufficient. Types: `port-group` (default), `address-group`, `ipv6-address-group`. The `external_id` UUID in group responses is what firewall policies reference. Policy `create`/`update` resolve group **names** for you via `--src-port-group` / `--dst-port-group` / `--src-address-group` / `--dst-address-group` flags (or `dst_port_group` / `dst_address_group` shorthand fields in `--from-file` JSON).
+
 ## NAT
 
 ```bash
@@ -162,7 +192,7 @@ Use `nat policies update <ID>` to modify an existing rule. Pass any
 combination of `--name`, `--type`, `--enabled`, address/port flags, or
 `--from-file`. Only the specified fields are changed.
 
-NAT types: `masquerade` (outgoing interface address), `source` (explicit rewrite), `destination` (port forwarding/DNAT). NAT routes through the Session v2 API, so credentials are required even in Hybrid mode.
+NAT types: `masquerade` (outgoing interface address), `source` (explicit rewrite), `destination` (port forwarding/DNAT). NAT routes through the Session v2 API: an API key on UniFi OS is sufficient, and session-only profiles work too (`nat policies list` populates from the session refresh snapshot). Only pure-Integration setups without session HTTP access cannot manage NAT.
 
 ## ACL
 
@@ -183,13 +213,13 @@ unifly acl reorder --set <ID1,ID2,...>          # Apply new order
 ```bash
 unifly dns list
 unifly dns get <ID>
-unifly dns create --record-type A --domain "nas.home" --value "10.0.10.5"
+unifly dns create --record-type a --domain "nas.home" --value "10.0.10.5"
 unifly dns create -F dns.json
 unifly dns update <ID> -F dns.json
 unifly dns delete <ID>
 ```
 
-Supported record types: `A`, `AAAA`, `CNAME`, `MX`, `TXT`, `SRV`, `Forward`.
+Supported record types: `a`, `aaaa`, `cname`, `mx`, `txt`, `srv`, `forward`. The `--record-type` values are **lowercase**; uppercase `A` is rejected by argument parsing. Table output displays the familiar short uppercase names (`A`, `AAAA`, ...).
 
 ## Traffic Lists
 
@@ -294,30 +324,29 @@ unifly system poweroff                          # Power off hardware (UDM only)
 `reboot` and `poweroff` are destructive and require confirmation (`-y` to skip).
 {% end %}
 
-## Other Commands
+## VPN
 
 ```bash
-unifly topology                                 # Network tree visualization
-unifly vpn servers                              # List VPN servers
-unifly vpn tunnels                              # List site-to-site tunnels
-unifly vpn site-to-site list                    # List session site-to-site VPN records
+unifly vpn servers                              # List VPN servers (Integration)
+unifly vpn tunnels                              # List site-to-site tunnels (Integration)
+unifly vpn site-to-site list                    # List site-to-site VPN records
 unifly vpn site-to-site get <ID>                # Inspect one site-to-site VPN record
-unifly vpn site-to-site create -F vpn.json      # Create a session site-to-site VPN
-unifly vpn site-to-site update <ID> -F vpn.json # Update a session site-to-site VPN
-unifly vpn site-to-site delete <ID>             # Delete a session site-to-site VPN
-unifly vpn remote-access list                   # List session remote-access VPN servers
+unifly vpn site-to-site create -F vpn.json      # Create a site-to-site VPN
+unifly vpn site-to-site update <ID> -F vpn.json # Update a site-to-site VPN
+unifly vpn site-to-site delete <ID>             # Delete a site-to-site VPN
+unifly vpn remote-access list                   # List remote-access VPN servers
 unifly vpn remote-access get <ID>               # Inspect one remote-access VPN server
-unifly vpn remote-access create -F vpn.json     # Create a session remote-access VPN server
-unifly vpn remote-access update <ID> -F vpn.json # Update a session remote-access VPN server
+unifly vpn remote-access create -F vpn.json     # Create a remote-access VPN server
+unifly vpn remote-access update <ID> -F vpn.json # Update a remote-access VPN server
 unifly vpn remote-access suggest-port           # Suggest available OpenVPN ports
 unifly vpn remote-access download-config <ID>   # Download an OpenVPN client config
-unifly vpn remote-access delete <ID>            # Delete a session remote-access VPN server
-unifly vpn clients list                         # List configured session VPN clients
+unifly vpn remote-access delete <ID>            # Delete a remote-access VPN server
+unifly vpn clients list                         # List configured VPN clients
 unifly vpn clients get <ID>                     # Inspect one configured VPN client
 unifly vpn clients create -F vpn.json           # Create a configured VPN client
 unifly vpn clients update <ID> -F vpn.json      # Update a configured VPN client
 unifly vpn clients delete <ID>                  # Delete a configured VPN client
-unifly vpn connections list                     # List session VPN client connections
+unifly vpn connections list                     # List VPN client connections
 unifly vpn connections get <ID>                 # Inspect one VPN client connection
 unifly vpn connections restart <ID>             # Restart one VPN client connection
 unifly vpn peers list [SERVER_ID]               # List WireGuard peers, optionally by server
@@ -328,10 +357,44 @@ unifly vpn peers delete <SERVER_ID> <ID>        # Delete a WireGuard peer
 unifly vpn peers subnets                        # List subnets already used by peers
 unifly vpn magic-site-to-site list              # List magic site-to-site VPN configs
 unifly vpn magic-site-to-site get <ID>          # Inspect one magic site-to-site VPN config
-unifly vpn settings list                        # List session VPN-related site settings
+unifly vpn settings list                        # List VPN-related site settings
 unifly vpn settings get teleport                # Inspect one VPN setting
 unifly vpn settings set teleport --enabled true # Toggle a VPN setting
 unifly vpn settings patch peer-to-peer -F peer.json   # Apply a JSON payload
+```
+
+Gotchas: `servers` and `tunnels` are read-only Integration API inventory; everything else is Session-backed and works with an API key on UniFi OS. Create and update for `site-to-site`, `remote-access`, `clients`, and `peers` are payload-driven: build the JSON with `--from-file` (see the [examples/](https://github.com/hyperb1iss/unifly/tree/main/skills/unifly/examples) templates). Sensitive material such as WireGuard private keys and IPsec pre-shared keys is **redacted** in both `get` and `create` output; reconstruct those fields explicitly in update payloads if the controller requires them unchanged. The full walkthrough lives on the [VPN page](/guide/vpn).
+
+## Settings
+
+```bash
+unifly settings list                            # All site setting sections
+unifly settings get dpi                         # One section
+unifly settings set dpi enabled true            # Patch one field
+unifly settings set usg --data '{"mss_clamp": "auto"}'  # Merge a JSON object
+unifly settings export                          # Full JSON dump of every section
+```
+
+Site-level settings live in Session API setting sections. `set` performs a read-modify-write of the whole section, and `get` masks `x_`-prefixed secret fields in table mode (`-o json` shows everything). Session-gated: needs an API key on UniFi OS or session credentials. Details on the [Site Settings page](/guide/settings).
+
+## Cloud (Site Manager)
+
+```bash
+unifly cloud hosts                              # Consoles visible to the API key
+unifly cloud sites                              # Sites across the fleet
+unifly cloud devices                            # Devices across all consoles
+unifly cloud devices --host <ID>                # Scope to one console
+unifly cloud isp                                # ISP metrics
+unifly cloud sdwan                              # SD-WAN configs
+unifly cloud switch <SITE>                      # Point the cloud profile at a site
+```
+
+`cloud` talks directly to the Site Manager fleet API at `api.ui.com` with a Site Manager API key; no controller connection is involved. With `auth_mode = "cloud"`, regular Integration-backed commands (`networks list`, `firewall policies list`, ...) tunnel through the cloud connector to one console. Set up with `unifly config cloud-setup`; the full story is on the [Cloud & Site Manager page](/guide/cloud).
+
+## Other Commands
+
+```bash
+unifly topology                                 # Network tree visualization
 unifly radius profiles                          # List RADIUS profiles
 unifly wans list                                # List WAN interfaces
 unifly sites list                               # List sites
@@ -356,6 +419,7 @@ unifly api integration/v1/sites/<site-id>/hotspot/vouchers/<id> -m DELETE       
 
 ```bash
 unifly config init                              # Interactive setup wizard
+unifly config cloud-setup                       # Guided Site Manager (cloud) profile
 unifly config show                              # Show resolved config
 unifly config set auth_mode hybrid              # Set a config value
 unifly config set-password                      # Store password in keyring
@@ -364,13 +428,15 @@ unifly config profiles                          # List profiles (* = active)
 unifly config use <PROFILE>                     # Switch default profile
 ```
 
-Valid `config set` keys: `controller`, `site`, `auth_mode`, `api_key`, `api_key_env`, `username`, `insecure`, `timeout`, `ca_cert`.
+Valid `config set` keys: `controller`, `site`, `auth_mode`, `api_key`, `api_key_env`, `host_id`, `host_id_env`, `username`, `insecure`, `timeout`, `ca_cert`. `auth_mode` accepts `integration`, `session`, `hybrid`, or `cloud` (`legacy` is normalized to `session`).
 
 ## `--from-file` / `-F`
 
 Most create/update commands accept `-F <file.json>` to read the request body from a JSON file. This is the preferred approach for complex payloads.
 
-Accepted by: `networks`, `wifi`, `firewall policies`, `firewall zones`, `nat policies`, `acl`, `dns`, `traffic-lists`, `hotspot`, `vpn site-to-site`, `vpn remote-access`, `vpn clients`, `vpn peers`.
+Accepted by: `networks`, `wifi`, `firewall policies`, `firewall zones`, `firewall groups`, `nat policies`, `acl`, `dns`, `traffic-lists`, `vpn site-to-site`, `vpn remote-access`, `vpn clients`, `vpn peers`, `vpn settings patch`, and `devices port-set` (JSONC for switch port config-as-code).
+
+JSONC is accepted everywhere: comments and trailing commas are stripped before parsing.
 
 ```bash
 unifly networks create -F network.json
@@ -379,17 +445,33 @@ unifly firewall policies create -F policy.json
 
 See [examples/](https://github.com/hyperb1iss/unifly/tree/main/skills/unifly/examples) for payload templates.
 
-## Integration Filter DSL
+## List Filtering (`--filter`)
 
-`--filter` on list commands accepts a small expression language:
+`--filter` on list commands is evaluated **client-side** and supports exactly one expression, with three operators:
 
 ```bash
-unifly devices list --filter "state.eq('ONLINE') && model.startswith('U6')"
+unifly devices list --filter "state.eq('Online')"
+unifly clients list --filter "name.contains('ring')"
+unifly networks list --filter "vlan.in('20','30','40')"
 ```
 
-Operators: `eq`, `neq`, `contains`, `startswith`, `endswith`, `gt`, `lt`, `gte`, `lte`, `in`. Combine with `&&` and `||`.
+Field paths address the JSON output shape (dot notation for nesting). An unparseable expression matches nothing and exits 0, so a silent empty result usually means a typo in the filter, not an empty collection.
 
-Only Integration API commands respect `--filter`.
+The full server-side Integration filter DSL (`neq`, `gt`/`lt`, `startswith`, `&&`/`||`) applies only to `hotspot purge --filter`, which passes the expression to the controller.
+
+## Capturing Created IDs
+
+Create commands print the created entity on stdout in the requested output format, with the human confirmation line on stderr. That makes ID capture a one-liner:
+
+```bash
+NET_ID=$(unifly networks create --name "IoT" --vlan 30 \
+  --management gateway --ipv4-host "10.0.30.1/24" -o json | jq -r '.id')
+
+# -o plain emits just the new ID
+ZONE_ID=$(unifly firewall zones create --name "IoT Zone" -o plain)
+```
+
+`sites create` is the exception: the controller returns no record to print. VPN create output has sensitive fields (private keys, PSKs) redacted, same as `get`.
 
 ## Global Flags
 
@@ -398,15 +480,17 @@ Only Integration API commands respect `--filter`.
 -c, --controller <URL>   Controller URL (overrides profile)
 -s, --site <SITE>        Site name or UUID
 -o, --output <FORMAT>    Output: table, json, json-compact, yaml, plain
--k, --insecure           Accept self-signed TLS certificates
+-k, --insecure           Accept self-signed TLS certs (--insecure=false forces verification)
 -v, --verbose            Increase verbosity (-v, -vv, -vvv)
 -q, --quiet              Suppress non-error output
 -y, --yes                Skip confirmation prompts
-    --timeout <SECS>     Request timeout (default: 30)
+    --timeout <SECS>     Request timeout (default 30, profiles may override)
     --color <MODE>       Color: auto, always, never
     --no-cache           Force fresh login (bypass session cache)
     --api-key <KEY>      Integration API key (one-shot override)
 ```
+
+`--insecure` is tri-state: absent defers to the profile and `[defaults]`, `-k` / `--insecure` accepts self-signed certificates, and `--insecure=false` forces verification no matter what the config says. The explicit value requires the equals form (`--insecure false` does not parse). `--timeout` has no baked-in flag default; when the flag and `UNIFI_TIMEOUT` are absent, the profile's `timeout` wins, then `[defaults]`, then the built-in 30 seconds.
 
 ## Output Formats
 
@@ -428,4 +512,5 @@ unifly clients list -o plain | xargs -n1 unifly clients get
 - [TUI Dashboard](/reference/tui): real-time monitoring with keybindings
 - [Authentication](/guide/authentication): which auth mode enables which commands
 - [Configuration](/guide/configuration): profiles, environment variables, precedence
+- [VPN](/guide/vpn), [Switch Ports](/guide/switch-ports), [Site Settings](/guide/settings), [Cloud & Site Manager](/guide/cloud): feature deep-dives
 - [Troubleshooting](/troubleshooting): common errors and fixes

--- a/docs/content/reference/library.md
+++ b/docs/content/reference/library.md
@@ -15,7 +15,7 @@ Add to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-unifly-api = "0.8"
+unifly-api = "0.10"
 secrecy = "0.10"
 tokio = { version = "1", features = ["full"] }
 ```
@@ -131,6 +131,20 @@ end
 | ----------------------- | ------------------------------ | ------------------------------------------------ |
 | `Controller::connect()` | Long-lived apps (TUI, daemons) | Refresh loop (10s), WebSocket, command processor |
 | `Controller::oneshot()` | Fire-and-forget (CLI commands) | None. Single fetch, then done                    |
+
+## Fallible DNS Conversion
+
+Converting a raw Integration DNS response into a `DnsPolicy` is fallible. The `TryFrom<DnsPolicyResponse>` impl returns an `UnrecognizedDnsRecordType` error carrying the offending type token when the controller reports a record type the library doesn't model, instead of silently mislabeling it:
+
+```rust
+use unifly_api::model::DnsPolicy;
+
+let policy = DnsPolicy::try_from(response)?; // Err(UnrecognizedDnsRecordType) on unknown types
+```
+
+{% warning(title="Upgrading from 0.9") %}
+The infallible `From<DnsPolicyResponse> for DnsPolicy` impl is replaced by this `TryFrom`. It is the only breaking change in the 0.10 API for library consumers: switch call sites to `try_from` / `try_into` and handle (or propagate) the error.
+{% end %}
 
 ## Full Documentation
 

--- a/docs/content/reference/tui.md
+++ b/docs/content/reference/tui.md
@@ -1,6 +1,6 @@
 +++
 title = "TUI Dashboard"
-description = "10-screen terminal dashboard with keybindings and screen layouts"
+description = "11-screen terminal dashboard with keybindings and screen layouts"
 weight = 2
 +++
 
@@ -52,18 +52,19 @@ The dashboard packs eight live panels into a dense, information-rich overview:
 
 ### Global
 
-| Key                       | Action                 |
-| ------------------------- | ---------------------- |
-| `1`-`9`, `,`              | Jump to screen         |
-| `Tab` / `Shift+Tab`       | Next / previous screen |
-| `j` / `k` / `Up` / `Down` | Navigate up / down     |
-| `g` / `G`                 | Jump to top / bottom   |
-| `Ctrl+d` / `Ctrl+u`       | Page down / up         |
-| `Enter`                   | Select / expand detail |
-| `Esc`                     | Close detail / go back |
-| `/`                       | Search                 |
-| `?`                       | Help overlay           |
-| `q`                       | Quit                   |
+| Key                       | Action                              |
+| ------------------------- | ----------------------------------- |
+| `1`-`9`, `,`              | Jump to screen                      |
+| `Tab` / `Shift+Tab`       | Next / previous screen              |
+| `j` / `k` / `Up` / `Down` | Navigate up / down                  |
+| `g` / `G`                 | Jump to top / bottom                |
+| `Ctrl+d` / `Ctrl+u`       | Page down / up                      |
+| `Enter`                   | Select / expand detail              |
+| `Esc`                     | Close detail / go back              |
+| `/`                       | Search                              |
+| `?`                       | Help overlay                        |
+| `Ctrl+r`                  | Force reconnect (when disconnected) |
+| `q`                       | Quit                                |
 
 ### Screen-Specific
 
@@ -126,13 +127,16 @@ The TUI works with all authentication modes, but some screens degrade gracefully
 
 | Mode              | Dashboard | Devices  | Clients  | Events   | Stats    | WiFi     |
 | ----------------- | --------- | -------- | -------- | -------- | -------- | -------- |
-| API Key           | Partial   | Full     | Full     | No       | No       | Full     |
+| API Key           | Full      | Full     | Full     | No       | Full     | Full     |
 | Username/Password | Full      | Full     | Full     | Full     | Full     | Full     |
 | **Hybrid**        | **Full**  | **Full** | **Full** | **Full** | **Full** | **Full** |
+| Cloud             | Partial   | Full     | Partial  | No       | No       | No       |
 
 {% tip() %}
 **API Key mode** works for most TUI screens on UniFi OS. Use **Hybrid mode** only when you need live WebSocket event streaming (the Events screen). Statistics and device data are available via Session HTTP endpoints that API Key mode can reach.
 {% end %}
+
+**Cloud mode** routes Integration API traffic through the [Site Manager connector](/guide/cloud), one console at a time. Session-backed screens (Events, Stats, WiFi observability) need direct controller access and stay empty, and client rows miss their Session enrichment fields.
 
 ## Graceful Degradation
 
@@ -142,9 +146,9 @@ When data is unavailable (e.g., API-key-only mode without Session access), panel
 
 The TUI uses the [Opaline](https://crates.io/crates/opaline) theme engine with the SilkCircuit color palette. Press `,` to open Settings and use the theme selector to preview and switch themes. Theme changes take effect immediately and persist to `defaults.theme` in your config file. You can also set the initial theme via the `UNIFLY_THEME` environment variable at launch.
 
-{% warning(title="Known Limitation") %}
-Controller reconnect after a network interruption is currently broken. If the connection drops, restart the TUI to reconnect.
-{% end %}
+## Connection Resilience
+
+When a connection attempt fails or the controller drops mid-session, the TUI reconnects automatically. Retries use exponential backoff starting at 2 seconds and doubling up to a 30-second cap, and they continue indefinitely; the status bar shows the current attempt number while reconnecting. Press `Ctrl+r` while disconnected to retry immediately instead of waiting out the backoff.
 
 ## Next Steps
 

--- a/docs/content/reference/tui.md
+++ b/docs/content/reference/tui.md
@@ -130,7 +130,9 @@ The TUI works with all authentication modes, but some screens degrade gracefully
 | API Key           | Full      | Full     | Full     | No       | Full     | Full     |
 | Username/Password | Full      | Full     | Full     | Full     | Full     | Full     |
 | **Hybrid**        | **Full**  | **Full** | **Full** | **Full** | **Full** | **Full** |
-| Cloud             | Partial   | Full     | Partial  | No       | No       | No       |
+| Cloud             | Partial   | Partial  | Partial  | No       | No       | No       |
+
+Cloud mode's Devices screen lists device data through the connector but the management actions (`R` restart, `L` locate) are unavailable: the connector has no Session client to issue device commands.
 
 {% tip() %}
 **API Key mode** works for most TUI screens on UniFi OS. Use **Hybrid mode** only when you need live WebSocket event streaming (the Events screen). Statistics and device data are available via Session HTTP endpoints that API Key mode can reach.

--- a/docs/content/troubleshooting.md
+++ b/docs/content/troubleshooting.md
@@ -34,12 +34,16 @@ unifly -k devices list
 unifly config set insecure true
 ```
 
+The `unifly config init` wizard asks whether the controller uses a self-signed certificate and writes `insecure = true` into the profile when you confirm, so fresh profiles usually never hit this error. You can also set `insecure = true` in the `[defaults]` section to apply it to every profile that doesn't decide for itself.
+
 For production, provide a custom CA certificate:
 
 ```toml
 [profiles.production]
 ca_cert = "/path/to/your-ca.pem"
 ```
+
+To force certificate verification for one command regardless of profile or defaults, pass `--insecure=false`. The flag requires the equals form: `--insecure=false` works, `--insecure false` does not parse.
 
 ### "403 Forbidden" on POST/PUT/DELETE
 
@@ -108,13 +112,21 @@ export UNIFI_URL="https://192.168.1.1"
 
 ### Client list missing traffic/hostname/VLAN columns
 
-**Cause**: You're using API Key mode. These fields come from the Session API and require Hybrid mode.
+**Cause**: These fields come from the Session API, and your setup has no session HTTP access. On UniFi OS consoles an API key reaches the Session HTTP endpoints too, so API Key mode gets the enriched data automatically. Only pure-Integration setups miss it: classic standalone controllers that reject API keys on the session surface, or cloud-connector profiles.
 
 ```bash
-# Switch to Hybrid for enriched data
+# On a classic standalone controller, switch to Hybrid
 unifly config set auth_mode hybrid
 unifly config set-password
 ```
+
+Hybrid is otherwise only needed for live WebSocket features such as `events watch`.
+
+### DNS records show the wrong type
+
+**Cause**: Older unifly builds mislabeled unrecognized DNS record types as `Forward`. Current builds parse every type the controller reports and skip records they cannot classify (with a warning in verbose output). Upgrade unifly if `dns list` shows `Forward` for records the web UI shows as something else.
+
+Related gotcha: `dns create --record-type` takes lowercase values (`a`, `aaaa`, `cname`, `mx`, `txt`, `srv`, `forward`). Uppercase `A` is rejected by argument parsing, even though table output displays the familiar uppercase names.
 
 ### "events watch" hangs or shows nothing
 
@@ -135,6 +147,39 @@ unifly devices list --all
 # Or set a higher limit
 unifly clients list --limit 200
 ```
+
+## Cloud / Site Manager
+
+### "multiple cloud consoles are available"
+
+**Cause**: Your Site Manager API key can see more than one console, and the profile doesn't say which one to use. Unifly auto-resolves the console only when the key sees exactly one console, or exactly one that you own.
+
+```bash
+# List consoles and their IDs
+unifly cloud hosts
+
+# Pin one in the profile
+unifly config set host_id <ID>
+
+# Or override per command
+unifly --host-id <ID> networks list
+```
+
+### "no cloud consoles are accessible with the current API key"
+
+**Cause**: The API key exists but its role doesn't grant access to any console. Site Manager keys are permission-scoped; a key created with a restricted role can authenticate and still see nothing.
+
+Check the key's permissions at [unifi.ui.com](https://unifi.ui.com) under your account's API keys, or generate a new key with access to the consoles you need.
+
+### Cloud profile misbehaving in other ways
+
+Re-run the guided setup. It validates the API key against the fleet API, lists the consoles the key can actually see, and writes a clean cloud profile:
+
+```bash
+unifly config cloud-setup
+```
+
+Session-only commands (`events watch`, `stats`, Wi-Fi observability, admin) fail in cloud mode by design; they need direct controller access. See [Cloud & Site Manager](/guide/cloud) for the full boundary.
 
 ## TUI Issues
 
@@ -202,7 +247,8 @@ UNIFI_TOTP=$(op read "op://Vault/UniFi/one-time password") unifly devices list
 - **`firewall policies patch`** is the fast path for toggling `enabled`/`logging`. Use it instead of `update` when only those fields change
 - **`networks refs <id>`** checks what depends on a network before you delete it. No equivalent exists for other entities yet
 - **`admin revoke`** takes a positional admin ID, not a `--email` flag
-- **Controller reconnect** is currently broken in the TUI. If the connection drops, restart the TUI
+- **Create commands print the created entity on stdout** in the requested format, so `create -o json | jq -r .id` captures the new ID directly (the human confirmation goes to stderr). `sites create` is the exception: the controller returns no record
+- **The TUI reconnects automatically** after a connection drop, with exponential backoff (2s doubling to a 30s cap). Press `Ctrl+r` while disconnected to retry immediately
 
 ## Still Stuck?
 


### PR DESCRIPTION
## 🎯 What

Brings the Zola docs site up to the 0.10.0 surface: every stale page corrected against the code, and four new guide pages for the features that had none (Cloud/Site Manager, VPN, switch-port config-as-code, site settings).

## 🔍 Why

A code-grounded survey found the site describing a different product: a "reconnect is broken" warning for a TUI that auto-reconnects, a CLI reference whose DNS example the binary rejects, "two APIs" prose for a triple-path tool, a 26-row command table for a 28-command CLI, and zero coverage of VPN, switch ports, settings, or cloud — the headline 0.10 features.

## 🛠️ How

Five commits, seventeen files, all under `docs/content/`. Highlights: the false reconnect warnings replaced with the real resilience behavior (backoff, attempt counter, Ctrl+r); the CLI reference rebuilt for 28 commands with new switch-ports, firewall-groups, VPN, settings, and cloud sections plus a Capturing Created IDs block; the filter docs rewritten to the real client-side eq/contains/in grammar; auth pages gain the cloud mode and the corrected keyring precedence; the library page documents the `From` → `TryFrom` break with `UnrecognizedDnsRecordType`; architecture pages drop the last "Legacy" holdovers and describe the Site Manager path; and the four new guide pages slot in at weights 5 through 8.

## 🧪 Testing

`zola build` → 16 pages, 0 orphans; `zola check` clean; every internal link validated against the built output; `npx prettier --check docs/content/` passes. Every behavioral claim was re-verified against the clap definitions, handlers, and models before writing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Added comprehensive guidance for Cloud Mode, Site Manager access, fleet queries, site selection, and cloud limitations.
  - Expanded CLI and TUI references for VPN management, switch-port configuration, site settings, firewall groups, JSONC updates, filtering, and reconnect controls.
  - Added dedicated guides for VPNs, switch ports, and site settings.
  - Updated authentication, configuration, troubleshooting, quick-start, and API architecture documentation.
  - Documented expanded command coverage, credential precedence, TLS options, and improved TUI reconnection behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->