### PR TITLE
docs: refresh root docs, changelog, and skill for 0.10.0

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -23,7 +23,7 @@ infrastructure. A single `unifly` binary ships three user-facing surfaces:
   clients, connections, peers, magic-site-to-site, settings), Wi-Fi
   observability (neighbors, channels, roams, experience), site settings
   (`settings`), cloud fleet queries, and a raw `api` escape hatch.
-- **TUI dashboard** (`unifly tui`) -- 10-screen Ratatui interface for real-time
+- **TUI dashboard** (`unifly tui`) -- 11-screen Ratatui interface for real-time
   monitoring and interactive management.
 - **Agent skill** at `skills/unifly/SKILL.md`: bundled documentation that
   teaches AI agents to drive the CLI.
@@ -49,13 +49,14 @@ The project uses **just** for task orchestration. All recipes live in the
 just check              # fmt-check + maintainability + clippy + test
 
 # Individual gates
-just fmt-check          # nightly rustfmt, read-only
+just fmt-check          # nightly rustfmt + prettier, read-only
+just maintainability    # scripts/check-maintainability.sh line-count gate
 just clippy             # cargo clippy --workspace --all-targets
 just test               # cargo test --workspace
 
 # Fix-it automation
-just fix                # clippy --fix + cargo fmt --all
-just fmt                # cargo fmt --all
+just fix                # clippy --fix + cargo fmt + prettier --write
+just fmt                # cargo fmt --all + prettier --write
 
 # Running
 just cli <args>         # cargo run -p unifly -- <args>
@@ -66,6 +67,14 @@ just test-crate unifly-api
 just test-verbose       # cargo test --workspace -- --nocapture
 just snap-review        # cargo insta review for snapshot tests
 
+# End-to-end (dockerized controller, feature-gated)
+just e2e                # full lifecycle: up, wait, test, tear down
+just e2e-up             # start the controller container
+just e2e-wait           # poll until the controller is ready
+just e2e-build          # compile the gated e2e binary without running it
+just e2e-test           # run the suite against a running controller
+just e2e-down           # stop and remove the container
+
 # Build
 just build              # debug build (workspace)
 just build-release      # release build (workspace)
@@ -75,7 +84,9 @@ just install            # cargo install --path crates/unifly (CLI + TUI)
 just install-cli        # CLI without TUI dependencies
 
 # Docs and cleanup
-just doc                # cargo doc --workspace --open
+just doc                # cargo doc --workspace --no-deps --open
+just docs-build         # Zola docs site build + llms.txt generation
+just docs-serve         # Zola docs site with live reload
 just clean              # cargo clean
 ```
 
@@ -250,10 +261,14 @@ Integration gate is called by 8 handler files (acl, dns, hotspot,
 networks, traffic_lists, wifi, vpn for servers/tunnels, and firewall
 for policies and zones). The Session gate is called by `events`,
 `nat`, `firewall` (groups subgroup and group-name resolution inside
-policies), and `devices` (port-set / ports / ports-export / port-cycle
-/ tags). The `firewall` handler dispatches the gate per-subcommand
-rather than at the top level. New commands should add the appropriate
-gate call for clean error messages when the auth mode is insufficient.
+policies), `devices` (ports / ports-export / port-set), and `vpn`
+(status, health, site-to-site, remote-access, clients, connections,
+peers, magic-site-to-site, settings). The `firewall` and `vpn`
+handlers dispatch the gate per-subcommand rather than at the top
+level. The top-level `settings` command has no gate call; insufficient
+auth surfaces as a raw session-client error. New commands should add
+the appropriate gate call for clean error messages when the auth mode
+is insufficient.
 
 ### Output Formats
 
@@ -286,6 +301,16 @@ but functional. Used for MFA controllers and 1Password CLI integration via
 `--no-cache` forces a fresh Session login, bypassing the session cookie
 cache stored under the system config dir.
 
+Value resolution follows CLI flag/env > profile > `[defaults]` >
+builtin (30-second timeout, system TLS verification). A profile's
+explicit `ca_cert` beats an inherited `defaults.insecure = true`,
+since a configured CA still means verification. `--insecure` /
+`UNIFI_INSECURE` is tri-state (`Option<bool>` with `require_equals`):
+bare `-k` means true, `--insecure=false` forces verification over any
+profile or defaults value. `--timeout` has no clap default; the
+30-second fallback is applied during resolution so profile and
+`[defaults]` timeouts take effect.
+
 ---
 
 ## TUI Architecture
@@ -300,9 +325,9 @@ crates/unifly/src/tui/
   component.rs / screen.rs   # traits
   data_bridge.rs             # Controller streams -> App state
   app.rs / app/              # top-level App state + run loop
-  screens/                   # 10 screens (Dashboard, Devices, Clients,
+  screens/                   # 11 screens (Dashboard, Devices, Clients,
                              #  Networks, Firewall, Topology, Events, Stats,
-                             #  Onboarding, Settings)
+                             #  Wifi, Onboarding, Settings)
   widgets/                   # shared custom widgets
   forms/                     # editable form overlays (Networks, Settings)
 ```
@@ -355,25 +380,29 @@ Two error types, composed via `From` impls:
 crates/unifly-api/tests/
   integration_client_test.rs     # wiremock-based Integration API tests
   session_client_test.rs         # wiremock-based Session API tests
+  site_manager_client_test.rs    # wiremock-based Site Manager cloud tests
   controller_runtime_test.rs     # Controller lifecycle + refresh loop
 
 crates/unifly/tests/
   cli_test.rs                    # assert_cmd-based CLI tests (fast, no controller)
-  e2e_test.rs                    # end-to-end tests against a simulation controller
+  e2e_test.rs                    # gated e2e suite against a dockerized controller
 
-tests/fixtures/                  # repo-root shared test data
+tests/e2e/                       # docker-compose.yml + wait-for-controller.sh
 ```
 
 Unit tests are inline in source files under `#[cfg(test)] mod tests`.
-The e2e suite (`e2e_test.rs`) spins up a wiremock-backed simulation
-controller and runs full command flows including auth, refresh, and
-output validation.
+The e2e suite (`e2e_test.rs`) is feature-gated behind `--features e2e`
+and drives the built binary against a real UniFi Network controller
+running in simulation mode via `tests/e2e/docker-compose.yml`. `just
+e2e` runs the full lifecycle (up, wait, test, tear down); `UNIFLY_E2E_URL`,
+`UNIFLY_E2E_USERNAME`, `UNIFLY_E2E_PASSWORD`, `UNIFLY_E2E_SITE`, and
+`UNIFLY_E2E_TIMEOUT_SECS` override the connection defaults. CI runs the
+same lifecycle in `.github/workflows/e2e.yml`.
 
 ### Libraries
 
-- **wiremock**: mock HTTP servers for Integration/Session tests and the
-  e2e simulation controller. Serves static JSON fixtures from
-  `tests/fixtures/`.
+- **wiremock**: mock HTTP servers for the Integration, Session, and
+  Site Manager client test suites.
 - **insta**: snapshot tests for output formatting. `just snap-review`
   opens the interactive UI to approve changes. Snapshot files live next to
   the test as `.snap` or `.snap.new`.
@@ -390,9 +419,11 @@ snapshot diffing is fast even in debug builds.
 
 - Unit tests should be pure and deterministic. No real network calls.
 - Integration tests use wiremock or assert_cmd, never a real controller.
+  The one carve-out is the feature-gated e2e suite, which targets the
+  dockerized controller and never runs in a default `cargo test`.
 - Tests must not require a specific UniFi hardware or firmware version.
-- The TUI has no automated test coverage yet. Adding tests here is
-  welcomed.
+- The TUI has inline unit tests (effects, forms, screen state) but no
+  `ratatui::TestBackend` render harness yet. Adding one is welcomed.
 
 ---
 
@@ -603,11 +634,29 @@ workflow.
   `key` (e.g. `"US"`), and `name` (e.g. `"United States"`).
 - **Session v2 observability routes return raw JSON**, not the classic
   `{meta, data}` envelope. Use `get_raw()` / `raw_get()` patterns.
-- **Device `radios` is always empty**. Parsing from the `interfaces`
-  JSON is not yet implemented. Known gap.
+- **Device `radios` come from the session `radio_table`**, merged with
+  `radio_table_stats` by `convert.rs::parse_session_radios`. The
+  Integration `interfaces` JSON is not the source.
 
 ### CLI Quirks
 
+- **Create commands print the created entity on stdout** in the selected
+  `--output` format: `-o plain` emits the bare ID, `-o json | jq -r .id`
+  is the capture idiom. The confirmation message goes to stderr.
+  `sites create` prints nothing (the controller returns no record). VPN
+  create responses pass through session-query redaction, so generated
+  private keys and PSKs stay off stdout. A response that cannot be
+  rendered warns on stderr and still exits zero; the create succeeded,
+  and failing would invite duplicate-create retries.
+- **`nat policies list` works in session-only auth.** The session
+  refresh snapshot fetches the v2 NAT inventory alongside the other
+  session collections.
+- **Wire formats follow Ubiquiti's OpenAPI spec, not intuition**
+  (#26/#27). Port ranges are `start`/`stop` on the wire, never
+  `startPort`/`endPort` (that string appears nowhere in the spec). DNS
+  record types are `*_RECORD` tokens (`A_RECORD`, not `A`). Integration
+  list pages decode per-item so one unparseable record cannot blank a
+  collection, and pagination advances by the server-reported count.
 - **Default list limit is 25** with a silent truncation hint. Agents and
   scripts should pass `--all` or `--limit 200+` for enumeration.
 - **`events watch --types` takes `EventCategory` enum values** (Device,
@@ -679,6 +728,14 @@ remote-access suggest-port` and `vpn remote-access download-config
 - **Panic hooks must be installed before terminal setup** so that panics
   restore the terminal state before crashing. `terminal::install_hooks`
   handles this.
+- **The data bridge auto-reconnects.** Failed connects retry with
+  exponential backoff (2s doubling to a 30s cap, indefinitely), emitting
+  `Reconnecting`/`Disconnected` actions so the status bar stays
+  truthful. `Ctrl+r` forces an immediate retry while disconnected by
+  cancelling the old bridge and spawning a fresh one. Bridge lifetimes
+  are serialized: each new bridge task first awaits its predecessor's
+  `JoinHandle`, so teardown always completes before the next connect
+  starts.
 
 ---
 
@@ -703,9 +760,15 @@ remote-access suggest-port` and `vpn remote-access download-config
 - `ROADMAP.md`: forward-looking plans
 - `AGENTS.md` / `CLAUDE.md`: this file (CLAUDE.md is a symlink)
 - `skills/unifly/SKILL.md`: agent skill for USING the CLI
+- `docs/content/`: Zola docs site content (guide, reference, architecture)
+- `docs/config.toml`: Zola site configuration
 - `docs/images/`: committed screenshots and GIFs
 - `docs/plans/` --**scratch area, do not commit contents** (not currently
   gitignored but treat as ephemeral)
+
+The docs site deploys via `.github/workflows/docs.yml`, which triggers
+only on `docs/**` changes (and edits to the workflow itself). Root
+markdown changes do not redeploy the site.
 
 ### Scratch Areas
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -152,6 +152,33 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
   The session-only refresh snapshot omitted NAT entirely, so rules
   created and persisted on the controller were invisible to the list
   command while update and delete still worked against them.
+- **DNS policies parse modern `*_RECORD` type tokens** (#27). Controllers
+  send `A_RECORD`-style identifiers; the old short-name tables mislabeled
+  every non-forward record as `ForwardDomain` with an empty value, and
+  `dns create` / `dns update` emitted tokens the controller rejects. One
+  canonical mapping now covers read and write, unknown record types are
+  skipped with a warning instead of mislabeled, and the CLI shows short
+  DNS names (`A`, `CNAME`, `Forward`).
+- **Firewall policy lists survive real controller payloads** (#26). Port
+  ranges arrive as `start`/`stop` per Ubiquiti's OpenAPI spec; the model
+  demanded invented `startPort`/`endPort` names, and one failing policy
+  blanked the entire list. Integration list pages now also decode
+  per-item, so a single unparseable record can never empty a collection,
+  and pagination advances by the server-reported wire count so dropped
+  items cannot truncate a scan.
+- **The TUI honors CLI flag and env overrides** (#25). The profile path
+  dropped `--insecure`, `--site`, `--api-key`, `--totp`, `--no-cache`,
+  and `--controller`, so `UNIFI_INSECURE=true unifly tui -k` failed TLS
+  against self-signed certs while the CLI worked; connect failures now
+  show the reason in the status bar instead of a silent "disconnected".
+- **Profile `timeout` takes effect.** The `--timeout` flag's baked-in
+  clap default made every profile timeout dead weight; resolution now
+  follows flag/env, then profile, then the 30-second default, including
+  cloud transports.
+- **Library consumers get a fallible DNS conversion.** The lossy
+  `From<DnsPolicyResponse>` impl is replaced by `TryFrom` returning a
+  typed `UnrecognizedDnsRecordType` error (breaking change for
+  `unifly-api` users).
 - Port range items in firewall policy payloads now serialize as
   `PORT_NUMBER_RANGE` instead of `PORT_RANGE`, which the UDM API rejects.
   `PORT_RANGE` is still accepted on read for backward compatibility.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -95,6 +95,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Changed
 
+- **Breaking for `unifly-api` consumers:** the lossy
+  `From<DnsPolicyResponse> for DnsPolicy` impl is replaced by `TryFrom`,
+  returning a typed `UnrecognizedDnsRecordType` error instead of
+  mislabeling unknown record types as `ForwardDomain`.
 - **Credential precedence reversed**: when both an explicit `api_key` (or
   `password`) is set in a profile's TOML config and a corresponding keyring
   entry exists, the explicit config value now wins. This is the opposite of
@@ -175,10 +179,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
   clap default made every profile timeout dead weight; resolution now
   follows flag/env, then profile, then the 30-second default, including
   cloud transports.
-- **Library consumers get a fallible DNS conversion.** The lossy
-  `From<DnsPolicyResponse>` impl is replaced by `TryFrom` returning a
-  typed `UnrecognizedDnsRecordType` error (breaking change for
-  `unifly-api` users).
 - Port range items in firewall policy payloads now serialize as
   `PORT_NUMBER_RANGE` instead of `PORT_RANGE`, which the UDM API rejects.
   `PORT_RANGE` is still accepted on read for backward compatibility.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -109,30 +109,46 @@ See `Cargo.toml` `[workspace.lints]` for the full configuration.
 crates/unifly-api/tests/
   integration_client_test.rs     # wiremock-based Integration API tests
   session_client_test.rs         # wiremock-based Session API tests
+  site_manager_client_test.rs    # wiremock-based Site Manager cloud tests
   controller_runtime_test.rs     # Controller lifecycle + refresh loop
 
 crates/unifly/tests/
   cli_test.rs                    # assert_cmd-based CLI tests
-  e2e_test.rs                    # end-to-end tests with simulation controller
+  e2e_test.rs                    # feature-gated e2e suite, dockerized controller
 ```
 
 Unit tests are inline in source files under `#[cfg(test)] mod tests`.
 
 ### Test Libraries
 
-| Library                         | Purpose                                                                |
-| ------------------------------- | ---------------------------------------------------------------------- |
-| **wiremock**                    | Mock HTTP servers for Integration/Session API tests and e2e simulation |
-| **insta**                       | Snapshot tests for output formatting (`just snap-review` to approve)   |
-| **assert_cmd** + **predicates** | End-to-end CLI tests that spawn the built binary                       |
-| **tempfile**                    | Per-test config dir isolation                                          |
-| **tokio-test**                  | Poll-based async unit tests                                            |
-| **pretty_assertions**           | Better diffs on assertion failures                                     |
+| Library                         | Purpose                                                              |
+| ------------------------------- | -------------------------------------------------------------------- |
+| **wiremock**                    | Mock HTTP servers for Integration/Session/Site Manager API tests     |
+| **insta**                       | Snapshot tests for output formatting (`just snap-review` to approve) |
+| **assert_cmd** + **predicates** | End-to-end CLI tests that spawn the built binary                     |
+| **tempfile**                    | Per-test config dir isolation                                        |
+| **tokio-test**                  | Poll-based async unit tests                                          |
+| **pretty_assertions**           | Better diffs on assertion failures                                   |
+
+### End-to-End Tests
+
+The e2e suite (`crates/unifly/tests/e2e_test.rs`) drives the built binary against a real UniFi Network controller running in simulation mode inside Docker (`tests/e2e/docker-compose.yml`). It is feature-gated behind `--features e2e` and never runs in a default `cargo test`.
+
+```bash
+just e2e            # full lifecycle: start controller, wait, test, tear down
+just e2e-up         # start the controller container
+just e2e-wait       # poll until the controller is ready
+just e2e-build      # compile the gated test binary without running it
+just e2e-test       # run the suite against a running controller
+just e2e-down       # stop and remove the container
+```
+
+Connection defaults are overridable via `UNIFLY_E2E_URL`, `UNIFLY_E2E_USERNAME`, `UNIFLY_E2E_PASSWORD`, `UNIFLY_E2E_SITE`, and `UNIFLY_E2E_TIMEOUT_SECS`. CI runs the same lifecycle in `.github/workflows/e2e.yml`.
 
 ### Test Policy
 
 - Unit tests should be pure and deterministic. No real network calls.
-- Integration tests use wiremock or assert_cmd, never a real controller.
+- Integration tests use wiremock or assert_cmd, never a real controller. The feature-gated e2e suite is the one exception: it targets the dockerized controller and only runs through the `just e2e*` recipes or an explicit `--features e2e`.
 - Tests must not require a specific UniFi hardware or firmware version.
 
 ## Pull Request Workflow

--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ UniFi controllers expose multiple APIs with different capabilities. unifly unifi
 > npx skills add hyperb1iss/unifly
 > ```
 >
-> **Humans** get a gorgeous 10-screen TUI, shell completions, pipe-friendly output, and the quiet satisfaction of never opening the UniFi web UI again. Keep scrolling to [Install](#-install).
+> **Humans** get a gorgeous 11-screen TUI, shell completions, pipe-friendly output, and the quiet satisfaction of never opening the UniFi web UI again. Keep scrolling to [Install](#-install).
 
 ---
 
@@ -80,7 +80,7 @@ UniFi controllers expose multiple APIs with different capabilities. unifly unifi
 | Capability                    | What You Get                                                                                                                                                                                                        |
 | ----------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | 🔮 **Triple-Path API Engine** | Integration API + Session API via a single API key on UniFi OS, plus Site Manager cloud fleet and connector support. Hybrid mode adds WebSocket for live event streaming                                            |
-| ⚡ **Real-Time TUI**          | 10-screen dashboard with SilkCircuit octant traffic charts, CPU/MEM gauges, live client counts, zoomable topology, and auto-detected graphics-protocol charts (Kitty/Sixel/iTerm2)                                  |
+| ⚡ **Real-Time TUI**          | 11-screen dashboard with SilkCircuit octant traffic charts, CPU/MEM gauges, live client counts, zoomable topology, and auto-detected graphics-protocol charts (Kitty/Sixel/iTerm2)                                  |
 | 🦋 **28 Top-Level Commands**  | Devices and switch port config-as-code, clients, networks, WiFi, firewall policies/zones/groups, ACLs, NAT, DNS, full VPN surface, DPI, RADIUS, site settings, topology, cloud fleet, raw API passthrough, `tui`... |
 | 📡 **Wi-Fi Observability**    | Neighboring APs, regulatory channels, per-client Wi-Fi experience scores, roam timelines                                                                                                                            |
 | 💎 **Flexible Output**        | Table, JSON, compact JSON, YAML, and plain text. Pipe-friendly for scripting                                                                                                                                        |
@@ -127,7 +127,7 @@ unifly config init            # Local controller
 unifly config cloud-setup     # Site Manager / cloud controller
 ```
 
-The local wizard walks you through controller URL, authentication method, and site selection. The cloud wizard validates your Site Manager API key, lets you pick a console by name, discovers its sites, and writes a ready-to-use cloud profile. Credentials can be stored in your OS keyring, referenced from `UNIFI_API_KEY`, or saved in plaintext config, depending on the path you choose.
+The local wizard walks you through controller URL, authentication method, and site selection, and asks whether the controller uses a self-signed certificate (defaulting yes for IPs and `.local`-style hostnames, no for public ones). The cloud wizard validates your Site Manager API key, lets you pick a console by name, discovers its sites, and writes a ready-to-use cloud profile. Credentials can be stored in your OS keyring, referenced from `UNIFI_API_KEY`, or saved in plaintext config, depending on the path you choose.
 
 Once configured:
 
@@ -136,6 +136,9 @@ unifly devices list              # All adopted devices
 unifly devices ports my-switch   # Live port states with connected clients
 unifly clients list              # Connected clients
 unifly networks list             # VLANs and subnets
+unifly firewall groups list      # Port and address groups (Session API)
+unifly vpn servers               # VPN server inventory
+unifly settings list             # Site-level setting sections
 unifly wifi neighbors            # Nearby APs your radios can see
 unifly clients wifi 10.0.0.42    # Per-client Wi-Fi experience score
 unifly events watch              # Live event feed (requires Hybrid auth)
@@ -149,6 +152,13 @@ unifly cloud switch default      # Re-target the active cloud profile to another
  a1b2c3d4-e5f6-7890-abcd-ef1234567890 | Office Gateway  | UDM-Pro         | ONLINE
  b2c3d4e5-f6a7-8901-bcde-f12345678901 | Living Room AP  | U6-LR           | ONLINE
  c3d4e5f6-a7b8-9012-cdef-123456789012 | Garage Switch   | USW-Lite-8-PoE  | ONLINE
+```
+
+Create commands print the created entity on stdout in the chosen `--output`
+format, so scripts capture IDs directly:
+
+```bash
+NET_ID=$(unifly networks create --name lab --management switch --vlan 42 -o json | jq -r .id)
 ```
 
 ---
@@ -210,16 +220,24 @@ connector's site names or internal references.
 
 ### Environment Variables
 
-| Variable         | Description                                           |
-| ---------------- | ----------------------------------------------------- |
-| `UNIFI_API_KEY`  | Integration API key                                   |
-| `UNIFI_HOST_ID`  | Site Manager console/host ID for cloud connector mode |
-| `UNIFI_URL`      | Controller URL                                        |
-| `UNIFI_PROFILE`  | Profile name                                          |
-| `UNIFI_SITE`     | Site name or UUID                                     |
-| `UNIFI_OUTPUT`   | Default output format                                 |
-| `UNIFI_INSECURE` | Accept self-signed TLS certs                          |
-| `UNIFI_TIMEOUT`  | Request timeout (seconds)                             |
+| Variable         | Description                                                |
+| ---------------- | ---------------------------------------------------------- |
+| `UNIFI_API_KEY`  | Integration API key                                        |
+| `UNIFI_USERNAME` | Session auth username                                      |
+| `UNIFI_PASSWORD` | Session auth password                                      |
+| `UNIFI_HOST_ID`  | Site Manager console/host ID for cloud connector mode      |
+| `UNIFI_URL`      | Controller URL                                             |
+| `UNIFI_PROFILE`  | Profile name                                               |
+| `UNIFI_SITE`     | Site name or UUID                                          |
+| `UNIFI_OUTPUT`   | Default output format                                      |
+| `UNIFI_INSECURE` | Accept self-signed TLS certs (`false` forces verification) |
+| `UNIFI_TIMEOUT`  | Request timeout (seconds)                                  |
+| `UNIFI_TOTP`     | TOTP code for MFA-enabled controllers                      |
+| `UNIFI_DEMO`     | Sanitize PII for demo recordings                           |
+
+Flags and environment variables override profile values, profiles override
+the `[defaults]` config section, and `[defaults]` overrides the built-in
+fallbacks (30-second timeout, system TLS verification).
 
 ---
 
@@ -270,12 +288,14 @@ still need direct Session API access.
 -p, --profile <NAME>     Controller profile to use
 -c, --controller <URL>   Controller URL (overrides profile)
 -s, --site <SITE>        Site name or UUID
+    --api-key <KEY>      Integration API key
 -o, --output <FORMAT>    Output: table, json, json-compact, yaml, plain
--k, --insecure           Accept self-signed TLS certificates
+-k, --insecure[=BOOL]    Accept self-signed TLS certs (--insecure=false forces verification)
+    --no-cache           Disable session caching (forces fresh login)
 -v, --verbose            Increase verbosity (-v, -vv, -vvv)
 -q, --quiet              Suppress non-error output
 -y, --yes                Skip confirmation prompts
-    --timeout <SECS>     Request timeout (default: 30)
+    --timeout <SECS>     Request timeout in seconds (default 30, profiles may override)
     --color <MODE>       Color: auto, always, never
 ```
 
@@ -299,7 +319,7 @@ unifly completions powershell | Out-String | Invoke-Expression
 
 ## 🖥️ TUI
 
-`unifly tui` launches a 10-screen real-time dashboard for monitoring and managing your network.
+`unifly tui` launches an 11-screen real-time dashboard for monitoring and managing your network.
 
 ```bash
 unifly tui                   # Launch with default profile
@@ -325,6 +345,7 @@ still outside the TUI surface today.
 | **Topology**   | Zoomable network tree with pan, zoom, fit-to-view                                                |
 | **Events**     | Live WebSocket stream with 10K buffer, pause, severity filtering                                 |
 | **Stats**      | WAN bandwidth, client counts, DPI breakdown (1h/24h/7d/30d)                                      |
+| **WiFi**       | Overview, per-client experience (signal, link rates), neighboring APs, and roaming sub-tabs      |
 | **Settings**   | Profile switching, theme selector, display preferences                                           |
 | **Onboarding** | First-run setup wizard                                                                           |
 
@@ -387,7 +408,7 @@ Two crates, clean dependency chain:
 | Crate          | Purpose                                                                                                                                                                          |
 | -------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | **unifly-api** | Async HTTP/WebSocket client, Controller lifecycle, reactive DataStore (`DashMap` + `tokio::watch`), entity models. Published on [crates.io](https://crates.io/crates/unifly-api) |
-| **unifly**     | Single binary: CLI commands + `unifly tui` dashboard via feature flags, profile/keyring config, 10-screen ratatui dashboard with SilkCircuit theme                               |
+| **unifly**     | Single binary: CLI commands + `unifly tui` dashboard via feature flags, profile/keyring config, 11-screen ratatui dashboard with SilkCircuit theme                               |
 
 Deep dive: [Architecture documentation](https://hyperb1iss.github.io/unifly/architecture/)
 
@@ -403,7 +424,16 @@ unifly config use office       # Switch default profile
 unifly -p home devices list    # One-off override
 ```
 
-Named profiles for multiple controllers, OS keyring credential storage, environment variable overrides, and TOML config files. Full details: [Configuration guide](https://hyperb1iss.github.io/unifly/guide/configuration)
+Named profiles for multiple controllers, OS keyring credential storage, environment variable overrides, and TOML config files. A `[defaults]` section supplies fallbacks for any profile that leaves a value unset:
+
+```toml
+# ~/.config/unifly/config.toml
+[defaults]
+insecure = false # accept self-signed certificates when true
+timeout = 30     # request timeout in seconds
+```
+
+CLI flags and environment variables win over profile values, which win over `[defaults]`. Full details: [Configuration guide](https://hyperb1iss.github.io/unifly/guide/configuration)
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -237,7 +237,10 @@ connector's site names or internal references.
 
 Flags and environment variables override profile values, profiles override
 the `[defaults]` config section, and `[defaults]` overrides the built-in
-fallbacks (30-second timeout, system TLS verification).
+fallbacks (30-second timeout, system TLS verification). One exception:
+`UNIFI_USERNAME` and `UNIFI_PASSWORD` fill in only when the profile does
+not set its own `username`/`password` — a profile's configured session
+credentials win over the environment.
 
 ---
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -8,7 +8,7 @@ Issues that exist in the current release and are documented so nobody wastes tim
 
 - **Backup restore is missing.** `unifly system backup` covers `create`, `list`, `download`, and `delete`. Restoring a downloaded backup file still has to go through the controller UI.
 - **`refs` only exists for networks.** `networks refs <id>` answers "what depends on this entity before I delete it?" — no equivalent yet for WiFi broadcasts, firewall zones, firewall groups, traffic-lists, or other delete-blocking entities.
-- **CLI test coverage is growing but not comprehensive.** `cli_test.rs` and the wiremock-backed `e2e_test.rs` simulation suite cover a lot of the surface, but firewall groups, switch port management, and the full VPN write surface have lighter coverage than older entities.
+- **CLI test coverage is growing but not comprehensive.** `cli_test.rs` and the dockerized `e2e_test.rs` suite cover a lot of the surface, including firewall groups CRUD, the NAT policy lifecycle, and switch port reads under session auth; the full VPN write surface and switch-port writes have lighter coverage than older entities.
 - **TUI snapshot test harness is missing.** Unit tests for effects, forms, and screen state exist (~20 files), but there is no `ratatui::TestBackend`-driven render harness that locks down visual output across changes.
 
 ## Next Up
@@ -23,6 +23,13 @@ Near-term priorities for the next 1-2 releases.
 
 Features that landed since the last roadmap update.
 
+- **TUI auto-reconnect.** The data bridge retries failed connects with exponential backoff (2 seconds doubling to a 30-second cap) and reports each attempt in the status bar; `Ctrl+r` forces an immediate retry while disconnected. Distinct from the reconnect lifecycle fix below, which made a second `connect()` possible; this makes the TUI drive it automatically.
+- **Create commands print the created entity.** Every create renders the created record on stdout in the chosen `--output` format (`-o plain` emits the bare ID) with the confirmation on stderr, so scripts capture IDs directly instead of re-listing by name. VPN create responses are redacted like `get`; `sites create` prints nothing because the controller returns no record.
+- **`[defaults]` config section honored.** `defaults.insecure` and `defaults.timeout` apply wherever a profile leaves the value unset, with flag/env > profile > `[defaults]` > builtin precedence and a tri-state `--insecure` that can force verification back on. `config init` asks about self-signed certificates up front instead of writing profiles that fail TLS on UDM-style controllers.
+- **Issue fix wave: #25, #26, #27.** The TUI honors CLI flag and env overrides (`--insecure`, `--site`, `--api-key`, and friends) and shows connect failures in the status bar; firewall policy lists survive real controller payloads (`start`/`stop` port ranges, per-item decode, pagination by the server-reported count); DNS policies parse modern `*_RECORD` type tokens on both read and write.
+- **Profile `timeout` takes effect.** The `--timeout` flag's baked-in clap default made every profile timeout dead weight; resolution follows flag/env, then profile, then `[defaults]`, then the 30-second builtin, including cloud transports.
+- **Fallible DNS conversion (semver break).** The lossy `From<DnsPolicyResponse>` impl is replaced by `TryFrom` returning a typed `UnrecognizedDnsRecordType` error, so `unifly-api` consumers must handle the `Result`.
+- **Session-auth e2e coverage.** The dockerized suite covers firewall groups CRUD, a NAT policy create/update/delete lifecycle, and switch port reads under session-only auth. The probing surfaced and fixed the session refresh snapshot leaving `nat policies list` permanently empty.
 - **Switch port management as code.** `devices ports`, `devices ports-export`, and `devices port-set` cover the full per-port surface (mode, native VLAN, tagged VLANs, PoE, speed) with JSONC `--from-file` payloads, splice semantics (omitted ports keep their override; `"reset": true` removes one), `--with-clients` enrichment, and `// last-seen <ISO8601>: <mac>` markers in `ports-export` for git-diff drift detection on config-as-code repos.
 - **Full VPN management surface.** `vpn site-to-site`, `vpn remote-access` (with `suggest-port` and `download-config`), `vpn clients`, `vpn peers` (with `subnets`), `vpn magic-site-to-site`, `vpn settings` (with `teleport`, `magic-site-to-site`, `openvpn`, and `peer-to-peer` flag groups), and `vpn connections` list/get/restart for the legacy v2 inventory. Most write paths accept `--from-file`.
 - **Firewall groups CRUD.** `firewall groups list/get/create/update/delete` for port, address, and IPv6 address groups. Firewall policies reference groups by name via `--dst-port-group` / `--dst-address-group` (and the matching `--from-file` shorthands), resolved to `external_id` UUIDs automatically.
@@ -40,7 +47,7 @@ Features that landed since the last roadmap update.
 - **Plugin manifest sync automated.** The shared release workflow's `version-files` input patches `.claude-plugin/plugin.json`, `.claude-plugin/marketplace.json`, `.cursor-plugin/plugin.json`, and `skills/unifly/SKILL.md` automatically on every bump.
 - **ClawHub skill publish automated.** `cicd.yml` runs `npx clawhub sync --root ./skills --all --changelog "Release v$VERSION"` on tag push.
 - **AUR package update automated.** The `update-aur` job in `cicd.yml` bumps `pkgver` and pushes the updated `PKGBUILD` via `github-actions-deploy-aur` on tag push.
-- **E2E test suite.** Full simulation controller with wiremock-backed end-to-end tests, plus a Site Manager client test suite (`site_manager_client_test.rs`).
+- **E2E test suite.** A feature-gated suite (`--features e2e`) drives the built binary against a dockerized UniFi controller running in simulation mode (`just e2e` for the full lifecycle), plus a Site Manager client test suite (`site_manager_client_test.rs`).
 - **Donate → Sponsor.** TUI status bar links to GitHub Sponsors.
 
 ## Wish List

--- a/skills/unifly/SKILL.md
+++ b/skills/unifly/SKILL.md
@@ -335,8 +335,9 @@ UNIFI_PROFILE=warehouse unifly system health
 7. **Create commands print the created entity on stdout** in the chosen
    `--output` format, with the confirmation on stderr. Capture IDs
    directly: `ID=$(unifly networks create ... -o json | jq -r .id)`;
-   `-o plain` emits the bare ID. `sites create` prints nothing (the
-   controller returns no record).
+   `-o plain` emits the bare ID. Exceptions that print nothing because
+   the controller returns no record: `sites create` and
+   `system backup create`.
 
 ## Agent Workflow
 

--- a/skills/unifly/SKILL.md
+++ b/skills/unifly/SKILL.md
@@ -24,10 +24,11 @@ description: >-
 unifly is a Rust CLI for managing Ubiquiti UniFi network infrastructure. It
 unifies the modern Integration API (REST, API key), the Session API (cookie
 plus CSRF), and Site Manager cloud APIs behind a single coherent interface,
-plus real-time WebSocket event streaming. 28 top-level commands cover devices,
-clients, networks, WiFi, firewall policies and zones, NAT policies, ACLs, DNS,
-traffic matching lists, hotspot vouchers, DPI, stats, backups, cloud fleet
-queries, and a raw API escape hatch.
+plus real-time WebSocket event streaming. 28 top-level commands cover devices
+and switch port config-as-code, clients, networks, WiFi, firewall policies,
+zones, and groups, NAT policies, ACLs, DNS, traffic matching lists, hotspot
+vouchers, DPI, stats, backups, the full VPN surface, site settings, cloud
+fleet queries, and a raw API escape hatch.
 
 Unique capabilities worth leading with when the user's task suits them:
 
@@ -62,12 +63,12 @@ unifly supports four modes. **API key mode is enough for most HTTP
 automation on UniFi OS controllers.** Choose **Hybrid** when the task needs
 live WebSocket features (`events watch`) or you want maximum compatibility.
 
-| Mode          | Credentials             | What It Unlocks                                                                                              |
-| ------------- | ----------------------- | ------------------------------------------------------------------------------------------------------------ |
-| `integration` | API key                 | Integration API plus session HTTP on UniFi OS: CRUD, device commands, stats, reservations, admin, event list |
-| `session`     | Username + password     | Session HTTP + WebSocket only: events watch, stats, device commands, DPI control, admin, backups             |
-| `hybrid`      | API key + username/pass | Everything above, including session WebSocket plus enriched records with maximum controller compatibility    |
-| `cloud`       | Site Manager API key    | Connector-routed Integration CRUD plus `unifly cloud` fleet commands against `api.ui.com`                    |
+| Mode          | Credentials             | What It Unlocks                                                                                                                                                            |
+| ------------- | ----------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `integration` | API key                 | Integration API plus session HTTP on UniFi OS: CRUD, device commands, stats, reservations, admin, event list                                                               |
+| `session`     | Username + password     | Session HTTP + WebSocket only: events watch, stats, device commands, DPI control, admin, backups, NAT policies, firewall groups, switch port config-as-code, site settings |
+| `hybrid`      | API key + username/pass | Everything above, including session WebSocket plus enriched records with maximum controller compatibility                                                                  |
+| `cloud`       | Site Manager API key    | Connector-routed Integration CRUD plus `unifly cloud` fleet commands against `api.ui.com`                                                                                  |
 
 Session WebSocket still rejects API keys, so `events watch` needs `session` or
 `hybrid`. Cloud mode does **not** expose Session API endpoints or WebSocket
@@ -331,6 +332,11 @@ UNIFI_PROFILE=warehouse unifly system health
    controller access.
 6. **Exit codes are meaningful.** `0` on success, non-zero on error. Capture
    stderr for diagnostics.
+7. **Create commands print the created entity on stdout** in the chosen
+   `--output` format, with the confirmation on stderr. Capture IDs
+   directly: `ID=$(unifly networks create ... -o json | jq -r .id)`;
+   `-o plain` emits the bare ID. `sites create` prints nothing (the
+   controller returns no record).
 
 ## Agent Workflow
 

--- a/skills/unifly/references/concepts.md
+++ b/skills/unifly/references/concepts.md
@@ -130,6 +130,8 @@ without username/password. Use this matrix to pick the right `auth_mode`.
 - `clients wifi <ip>`: `/v2/api/site/{site}/wifiman/{ip}/`
 - `devices` adopt, remove, restart, locate, port-cycle, upgrade, provision,
   speedtest (all route through `cmd/devmgr` and `cmd/stamgr`)
+- `devices ports`, `devices ports-export`, `devices port-set`: switch port
+  overrides via `/rest/device/{id}` (`port_overrides`)
 - `clients` authorize, unauthorize, block, unblock, kick, forget (via
   `cmd/stamgr`)
 - `dpi status | enable | disable`: `/set/setting/dpi`
@@ -144,6 +146,7 @@ without username/password. Use this matrix to pick the right `auth_mode`.
 - `vpn peers` (list/get/create/update/delete/subnets): `/v2/api/site/{site}/wireguard/*/users`
 - `vpn magic-site-to-site` (list/get): `/v2/api/site/{site}/magicsitetositevpn/configs`
 - `vpn settings` (list/get/set/patch): `/rest/setting`
+- `settings` (list/get/set/export): `/rest/setting`
 - `wifi neighbors`: `/stat/rogueap`
 - `wifi channels`: `/stat/current-channel`
 - `nat policies` (list/get/create/update/delete): Session v2 API
@@ -166,6 +169,14 @@ falls back to polling when no session cookie is available.
 - `clients find`: inherits the merged view
 - `devices list`: Integration fetch, Session API `num_sta` merged by MAC
 - `topology`: depends on merged `uplink_device_mac` for tree construction
+
+### Site Manager cloud (cloud auth mode)
+
+- `cloud hosts | sites | devices | isp | sdwan | switch`: direct calls to
+  the Site Manager fleet API at `api.ui.com/v1/`; no controller connection
+  needed. With `auth_mode = "cloud"`, Integration-backed commands tunnel
+  through the cloud connector; Session-only commands still need direct
+  controller access.
 
 ### Raw API escape hatch
 
@@ -200,8 +211,11 @@ falls back to polling when no session cookie is available.
    `clients wifi`), admin operations, and enriched `clients list` /
    `devices list`. Live `events watch` still will not.
 2. **"I have username + password only"** → `auth_mode = "session"`. Events,
-   stats, device commands work. Modern entities (DNS policies, NAT policies,
-   traffic lists, ACL) require Integration and will fail.
+   stats, device commands, NAT policies, firewall groups, switch port
+   config-as-code (`devices ports / ports-export / port-set`), and site
+   `settings` all work. Modern Integration entities (DNS policies, traffic
+   lists, ACL, firewall policies and zones) require Integration and will
+   fail.
 3. **"I have both"** → `auth_mode = "hybrid"`. Recommended when the task
    needs live WebSocket streaming or maximum controller compatibility.
 4. **"Agent will manage multiple sites/controllers"** → Use named profiles


### PR DESCRIPTION
## 🎯 What

Brings the root docs and the agent skill up to the 0.10.0 surface: README, AGENTS.md, CONTRIBUTING.md, ROADMAP.md, changelog catch-up entries, and the skill's auth-mode matrix.

## 🔍 Why

The same code-grounded survey that drove the site refresh found the root docs contradicting the code: an eleven-screen TUI documented as ten with the WiFi screen missing entirely, a testing section describing the dockerized e2e harness as "wiremock-backed" and pointing at a `tests/fixtures/` directory that does not exist, a "radios is always empty" gotcha for a field that populates, and a skill that told agents NAT would fail in session mode when it works.

## 🛠️ How

- README: WiFi screen row, 11-screen counts, complete env table with the resolution precedence, tri-state `--insecure`, the created-ID capture idiom, and a `[defaults]` example.
- AGENTS.md: e2e section rewritten for the real docker harness, the dead `tests/fixtures/` references removed, the radios gotcha corrected, new quirks for the create-stdout contract, session-mode NAT lists, and the #26/#27 wire-format lessons, plus the TUI reconnect behavior and the docs-site deploy caveat.
- CONTRIBUTING: an End-to-End Tests section documenting `just e2e` and the harness env vars, with the test-policy carve-out.
- ROADMAP: seven Recently Completed entries for the 0.10 work (the DNS `TryFrom` break called out as semver-relevant) and the e2e coverage gap narrowed.
- CHANGELOG: catch-up Fixed entries for the #25/#26/#27 wave, and the `TryFrom` break moved from Fixed into Changed with a breaking callout.
- Skill: NAT struck from the session-mode will-fail list, the gate matrix gains settings and cloud rows, and a create-stdout gotcha. Two survey items were dropped after code verification: `devices tags` is Integration-backed, and `settings` has no gate call.

## 🧪 Testing

`npx prettier --check` passes on every touched file; edited sections re-read for orphaned cross-references; skill gotcha numbering unchanged so no references needed fixing. Doc claims were re-verified against the clap definitions, `tui/screen.rs`, the justfile, and `tests/e2e/` before writing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the README and CLI guidance with the current 11-screen TUI, setup instructions, configuration precedence, global flags, WiFi support, and create-command output behavior.
  * Expanded authentication and command documentation for switch ports, VPN, site settings, cloud fleet queries, NAT policies, and firewall groups.
  * Added testing guidance for integration and Docker-based end-to-end workflows.
  * Updated the changelog and roadmap with recent reliability improvements and completed features.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->